### PR TITLE
fix: back button bg color

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -5,7 +5,9 @@ import { Flex, LinkText, Text, Theme } from "../lib"
 
 export const withDarkModeSwitcher: DecoratorFunction<React.ReactNode> = (story) => {
   const [mode, setMode] = useState<"light" | "dark" | "system">("system")
-  const [systemMode, setSystemMode] = useState<"light" | "dark">("light")
+  const [systemMode, setSystemMode] = useState<"light" | "dark">(
+    Appearance.getColorScheme() ?? "light"
+  )
 
   useEffect(() => {
     const subscription = Appearance.addChangeListener(
@@ -19,9 +21,11 @@ export const withDarkModeSwitcher: DecoratorFunction<React.ReactNode> = (story) 
 
   return (
     <Theme theme={theme}>
-      <Flex flex={1}>
+      <Flex flex={1} backgroundColor="background">
         <Flex flexDirection="row" justifyContent="space-around">
-          <Text color="orange">Dark mode: {mode}</Text>
+          <Text color="orange">
+            Dark mode: {mode} {mode === "system" && "(" + systemMode + ")"}
+          </Text>
           <LinkText color="orange" onPress={() => setMode("light")}>
             light
           </LinkText>

--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,10 +1,22 @@
 import { DecoratorFunction } from "@storybook/addons"
 import { useEffect, useState } from "react"
+import { atomWithStorage, createJSONStorage } from "jotai/utils"
+import AsyncStorage from "@react-native-async-storage/async-storage"
+import { useAtom } from "jotai"
 import { Appearance } from "react-native"
 import { Flex, LinkText, Text, Theme } from "../lib"
 
+const atomStorage = createJSONStorage<any>(() => AsyncStorage)
+const atomWithAsyncStorage = <T,>(key: string, initialValue: any) =>
+  atomWithStorage<T>(key, initialValue, {
+    ...atomStorage,
+    delayInit: true,
+  })
+
+const modeAtom = atomWithAsyncStorage<"light" | "dark" | "system">("dark-mode-mode", "system")
+
 export const withDarkModeSwitcher: DecoratorFunction<React.ReactNode> = (story) => {
-  const [mode, setMode] = useState<"light" | "dark" | "system">("system")
+  const [mode, setMode] = useAtom(modeAtom)
   const [systemMode, setSystemMode] = useState<"light" | "dark">(
     Appearance.getColorScheme() ?? "light"
   )

--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -19,6 +19,7 @@ if (parameters) {
 
 const getStories = () => {
   return [
+    require("../lib/atoms/BackButton/BackButton.stories.tsx"),
     require("../lib/atoms/Box/Box.stories.tsx"),
     require("../lib/atoms/Spacer/Spacer.stories.tsx"),
     require("../lib/elements/Avatar/Avatar.stories.tsx"),

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -286,6 +286,8 @@ PODS:
   - React-jsinspector (0.69.5)
   - React-logger (0.69.5):
     - glog
+  - react-native-flipper (0.176.1):
+    - React-Core
   - react-native-safe-area-context (4.4.1):
     - RCT-Folly
     - RCTRequired
@@ -441,6 +443,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-flipper (from `../node_modules/react-native-flipper`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -519,6 +522,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-flipper:
+    :path: "../node_modules/react-native-flipper"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   React-perflogger:
@@ -590,6 +595,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: e42f0b46de293a026c2fb20e524d4fe09f81f575
   React-jsinspector: e385fb7a1440ae3f3b2cd1a139ca5aadaab43c10
   React-logger: 15c734997c06fe9c9b88e528fb7757601e7a56df
+  react-native-flipper: 7e4b1c3fe1a2eecbe7304e5ff6b89231b3ec61dc
   react-native-safe-area-context: 99b24a0c5acd0d5dcac2b1a7f18c49ea317be99a
   React-perflogger: 367418425c5e4a9f0f80385ee1eaacd2a7348f8e
   React-RCTActionSheet: e4885e7136f98ded1137cd3daccc05eaed97d5a6

--- a/lib/atoms/BackButton/BackButton.stories.tsx
+++ b/lib/atoms/BackButton/BackButton.stories.tsx
@@ -1,3 +1,4 @@
+import { Flex } from "../../atoms/Flex"
 import { Text } from "../../elements/Text"
 import { List } from "../../storybookHelpers"
 import { BackButton, BackButtonWithBackground } from "./BackButton"
@@ -12,6 +13,9 @@ export const Styled = () => (
     <Text>Back button</Text>
     <BackButton />
     <Text>Back button with background</Text>
-    <BackButtonWithBackground />
+    <Flex>
+      <Flex backgroundColor="red" width={50} height={50} position="absolute" />
+      <BackButtonWithBackground />
+    </Flex>
   </List>
 )

--- a/lib/atoms/BackButton/BackButton.stories.tsx
+++ b/lib/atoms/BackButton/BackButton.stories.tsx
@@ -1,0 +1,17 @@
+import { Text } from "../../elements/Text"
+import { List } from "../../storybookHelpers"
+import { BackButton, BackButtonWithBackground } from "./BackButton"
+
+export default {
+  title: "BackButton",
+  component: BackButton,
+}
+
+export const Styled = () => (
+  <List style={{ marginLeft: 50 }} contentContainerStyle={{ alignItems: "flex-start" }}>
+    <Text>Back button</Text>
+    <BackButton />
+    <Text>Back button with background</Text>
+    <BackButtonWithBackground />
+  </List>
+)

--- a/lib/atoms/BackButton/BackButton.tsx
+++ b/lib/atoms/BackButton/BackButton.tsx
@@ -2,7 +2,7 @@ import { TouchableOpacity } from "react-native"
 import { ChevronIcon, CloseIcon } from "../../svgs"
 import { Flex } from "../Flex"
 
-interface BackButtonProps {
+export interface BackButtonProps {
   onPress?: () => void
   showX?: boolean
 }
@@ -20,7 +20,7 @@ export const BackButton = ({ onPress, showX = false }: BackButtonProps) => (
 export const BackButtonWithBackground = ({ onPress, showX = false }: BackButtonProps) => (
   <TouchableOpacity onPress={onPress}>
     <Flex
-      backgroundColor="white100"
+      backgroundColor="onBackgroundHigh"
       width={40}
       height={40}
       borderRadius={20}
@@ -28,9 +28,9 @@ export const BackButtonWithBackground = ({ onPress, showX = false }: BackButtonP
       justifyContent="center"
     >
       {showX ? (
-        <CloseIcon fill="onBackgroundHigh" width={26} height={26} />
+        <CloseIcon fill="background" width={26} height={26} />
       ) : (
-        <ChevronIcon fill="onBackgroundHigh" direction="left" />
+        <ChevronIcon fill="background" direction="left" />
       )}
     </Flex>
   </TouchableOpacity>

--- a/lib/atoms/BackButton/BackButton.tsx
+++ b/lib/atoms/BackButton/BackButton.tsx
@@ -20,7 +20,7 @@ export const BackButton = ({ onPress, showX = false }: BackButtonProps) => (
 export const BackButtonWithBackground = ({ onPress, showX = false }: BackButtonProps) => (
   <TouchableOpacity onPress={onPress}>
     <Flex
-      backgroundColor="onBackgroundHigh"
+      backgroundColor="background"
       width={40}
       height={40}
       borderRadius={20}
@@ -28,9 +28,9 @@ export const BackButtonWithBackground = ({ onPress, showX = false }: BackButtonP
       justifyContent="center"
     >
       {showX ? (
-        <CloseIcon fill="background" width={26} height={26} />
+        <CloseIcon fill="onBackgroundHigh" width={26} height={26} />
       ) : (
-        <ChevronIcon fill="background" direction="left" />
+        <ChevronIcon fill="onBackgroundHigh" direction="left" />
       )}
     </Flex>
   </TouchableOpacity>

--- a/package.json
+++ b/package.json
@@ -75,9 +75,11 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.2.1",
+    "jotai": "^1.12.0",
     "metro-react-native-babel-preset": "^0.72.1",
     "react": "18.2.0",
     "react-native": "0.69.5",
+    "react-native-flipper": "^0.176.1",
     "react-native-haptic-feedback": "^1.14.0",
     "react-native-linear-gradient": "^2.6.2",
     "react-native-reanimated": "^2.12.0",
@@ -85,6 +87,7 @@
     "react-native-svg": "^13.4.0",
     "react-test-renderer": "^18.2.0",
     "rimraf": "^3.0.2",
+    "rn-flipper-async-storage-advanced": "^1.0.4",
     "typescript": "^4.8.4"
   },
   "files": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,2 +1,12 @@
+import React from "react"
 import { StorybookUIRoot } from "../.storybook/Storybook"
-export { StorybookUIRoot as App }
+import FlipperAsyncStorage from "rn-flipper-async-storage-advanced"
+
+export const App = () => {
+  return (
+    <>
+      <FlipperAsyncStorage />
+      <StorybookUIRoot />
+    </>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6447,6 +6447,11 @@ joi@^17.2.1:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+jotai@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.12.0.tgz#2e22760289458f636f689ae0aa71cc4a089aa312"
+  integrity sha512-IhyBmjxU1sE2Ni/MUK7gQAb8QvCM6yd1/K5jtQzgQBmmjCjgfXZkkk1rYlQAIRp2KoQk0Y+yzhm1f5cZ7kegnw==
+
 js-sdsl@^4.1.4:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.1.5.tgz#1ff1645e6b4d1b028cd3f862db88c9d887f26e2a"
@@ -8030,6 +8035,11 @@ react-native-codegen@^0.69.2:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
+react-native-flipper@^0.176.1:
+  version "0.176.1"
+  resolved "https://registry.yarnpkg.com/react-native-flipper/-/react-native-flipper-0.176.1.tgz#fdf01e09160660d1c833d537909244965481275e"
+  integrity sha512-kioHzO9JzA2ReW9LfopIEUXeD6gDp3Mw6KjQbELvoLVIEMvCfGz59akezw4l/S8i6qkFVcnwh5c/7Z+L3nthQA==
+
 react-native-gradle-plugin@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/react-native-gradle-plugin/-/react-native-gradle-plugin-0.0.7.tgz#96602f909745239deab7b589443f14fce5da2056"
@@ -8457,6 +8467,11 @@ rimraf@~2.6.2:
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
     glob "^7.1.3"
+
+rn-flipper-async-storage-advanced@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/rn-flipper-async-storage-advanced/-/rn-flipper-async-storage-advanced-1.0.4.tgz#ca3d0c315a75f379fef3771cc6ee3bef2d774265"
+  integrity sha512-ixA6LJOxz+spdeJ8a2x6KimIiDCuKDky0ic5VaOHWIPSUcGmtmmZKJ98TQ0Uj3Cx/sM9K5VaUyjt2Gt1lrZNiw==
 
 run-async@^2.4.0:
   version "2.4.1"


### PR DESCRIPTION
Part of [MOPLAT-543]


<img width="315" alt="Screenshot 2022-12-23 at 12 07 24" src="https://user-images.githubusercontent.com/100233/209316465-d1d02780-611c-4f06-97c8-68207fd2315d.png">
<img width="320" alt="Screenshot 2022-12-23 at 12 07 32" src="https://user-images.githubusercontent.com/100233/209316480-e1d65473-3ed7-4dd7-99d3-7df05a992c5e.png">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.3.0--canary.30.3764849193.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@3.3.0--canary.30.3764849193.0
  # or 
  yarn add @artsy/palette-mobile@3.3.0--canary.30.3764849193.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->


[MOPLAT-543]: https://artsyproduct.atlassian.net/browse/MOPLAT-543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ