### PR TITLE
fix: dark mode colors

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -24,6 +24,7 @@ const getStories = () => {
     require("../lib/atoms/Spacer/Spacer.stories.tsx"),
     require("../lib/elements/Avatar/Avatar.stories.tsx"),
     require("../lib/elements/Checkbox/Checkbox.stories.tsx"),
+    require("../lib/elements/Input/Input.stories.tsx"),
     require("../lib/elements/Touchable/Touchable.stories.tsx"),
     require("../lib/molecules/MenuItem.stories.tsx"),
     require("../lib/svgs/icons.stories.tsx"),

--- a/lib/elements/Input/Input.stories.tsx
+++ b/lib/elements/Input/Input.stories.tsx
@@ -1,0 +1,24 @@
+import { MagnifyingGlassIcon } from "../../svgs"
+import { Flex } from "../../atoms"
+import { List } from "../../storybookHelpers"
+import { Input } from "./Input"
+
+export default {
+  title: "Input",
+  component: Input,
+}
+
+export const Styled = () => (
+  <List style={{ marginLeft: 50 }} contentContainerStyle={{ alignItems: "flex-start" }}>
+    <Flex width={300} height={120}>
+      <Input />
+      <Input
+        style={{ borderWidth: 0 }}
+        icon={<MagnifyingGlassIcon />}
+        focusable
+        placeholder="Search"
+        enableClearButton
+      />
+    </Flex>
+  </List>
+)

--- a/lib/elements/Input/Input.tsx
+++ b/lib/elements/Input/Input.tsx
@@ -265,7 +265,7 @@ export const Input = forwardRef<TextInput, InputProps>(
                 borderWidth: 1,
                 borderColor: color(computeBorderColor({ disabled, error: !!error, focused })),
                 minHeight: multiline ? INPUT_HEIGHT_MULTILINE : INPUT_HEIGHT,
-                backgroundColor: disabled ? color("black5") : color("white100"),
+                backgroundColor: disabled ? color("black5") : color("background"),
               },
               style,
             ]}

--- a/lib/svgs/MagnifyingGlassIcon.tsx
+++ b/lib/svgs/MagnifyingGlassIcon.tsx
@@ -7,7 +7,7 @@ export const MagnifyingGlassIcon = ({ fill, ...restProps }: IconProps) => {
     <Icon {...restProps} viewBox="0 0 18 18">
       <Path
         d="M11.5 3a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7zm0-1A4.5 4.5 0 1 0 16 6.5 4.49 4.49 0 0 0 11.5 2zM9.442 9.525l-.88-.88L2.06 15.06l.88.88 6.502-6.415z"
-        fill={color(fill)}
+        fill={color(fill) || "onBackgroundHigh"}
         fillRule="nonzero"
       />
     </Icon>

--- a/lib/svgs/MagnifyingGlassIcon.tsx
+++ b/lib/svgs/MagnifyingGlassIcon.tsx
@@ -7,7 +7,7 @@ export const MagnifyingGlassIcon = ({ fill, ...restProps }: IconProps) => {
     <Icon {...restProps} viewBox="0 0 18 18">
       <Path
         d="M11.5 3a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7zm0-1A4.5 4.5 0 1 0 16 6.5 4.49 4.49 0 0 0 11.5 2zM9.442 9.525l-.88-.88L2.06 15.06l.88.88 6.502-6.415z"
-        fill={color(fill) || "onBackgroundHigh"}
+        fill={color(fill ?? "onBackgroundHigh")}
         fillRule="nonzero"
       />
     </Icon>

--- a/lib/svgs/XCircleIcon.tsx
+++ b/lib/svgs/XCircleIcon.tsx
@@ -5,7 +5,7 @@ export const XCircleIcon = ({ fill, ...restProps }: IconProps) => {
   const color = useColor()
   return (
     <Icon {...restProps} viewBox="0 0 18 18">
-      <Circle cx={9} cy={9} r={9} fill="white" />
+      <Circle cx={9} cy={9} r={9} fill={color("background")} />
       <Path
         fillRule="evenodd"
         clipRule="evenodd"


### PR DESCRIPTION
![Screenshot 2022-12-23 at 13 01 04](https://user-images.githubusercontent.com/100233/209324721-936e344e-c46d-4afa-8d29-e65b8e3375bc.png)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.4.0--canary.31.3765151739.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@3.4.0--canary.31.3765151739.0
  # or 
  yarn add @artsy/palette-mobile@3.4.0--canary.31.3765151739.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
