### PR TITLE
tools: remeda -> lodash

### DIFF
--- a/lib/Theme.tsx
+++ b/lib/Theme.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react"
-import { isString } from "remeda"
+import { isString } from "lodash"
 import { ThemeContext, ThemeProvider } from "styled-components/native"
 import { AllThemesType, Color, SpacingUnit, Theme3Type, Theme5LightType, THEMES } from "./tokens"
 

--- a/lib/elements/Input/Input.tsx
+++ b/lib/elements/Input/Input.tsx
@@ -20,7 +20,7 @@ import { EyeOpenedIcon, XCircleIcon } from "../../svgs"
 import { Text } from "../Text"
 import { Spinner } from "../Spinner"
 import { MeasuredView } from "../../utils/MeasuredView"
-import { isArray, isString } from "remeda"
+import { isArray, isString } from "lodash"
 import { Color } from "../../tokens"
 
 const DEFAULT_FONT_SIZE = 16

--- a/lib/elements/Tabs/TabBarContainer.tsx
+++ b/lib/elements/Tabs/TabBarContainer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react"
 import { Animated, LayoutRectangle, ScrollView, View } from "react-native"
-import { compact } from "remeda"
+import { compact } from "lodash"
 import { Box } from "../../atoms"
 import { useColor } from "../../hooks"
 import { useScreenDimensions } from "../../utils/useScreenDimensions"

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -5,7 +5,7 @@
  */
 
 import { THEME_V3 } from "@artsy/palette-tokens"
-import { mapKeys, mapValues } from "remeda"
+import { mapKeys, mapValues } from "lodash"
 import {
   Color as ColorV3WithoutDevPurple,
   SpacingUnit as SpacingUnitV3Numbers,
@@ -46,7 +46,7 @@ const fixSpaceUnitsV3 = (
 } => {
   let fixed = units
 
-  fixed = mapKeys(fixed, (numberKey) => `${numberKey}`) as any
+  fixed = mapKeys(fixed, (_, numberKey) => `${numberKey}`) as any
 
   fixed = mapValues(fixed, (stringValueWithPx) => {
     const justStringValue = stringValueWithPx.split("px")[0]

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "@styled-system/core": "^5.1.2",
     "@styled-system/theme-get": "^5.1.2",
     "events": "^3.3.0",
+    "lodash": "^4.17.21",
     "react-nanny": "^2.15.0",
     "react-spring": "8.0.22",
-    "remeda": "^1.3.0",
     "styled-components": "^5.3.6",
     "styled-system": "^5.1.5"
   },
@@ -58,6 +58,7 @@
     "@tsconfig/react-native": "^2.0.3",
     "@types/events": "^3.0.0",
     "@types/jest": "^29.2.5",
+    "@types/lodash": "^4.14.191",
     "@types/react-native": "^0.69.6",
     "@types/react-test-renderer": "^18.0.0",
     "@types/styled-components": "^5.1.26",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,6 +2479,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash@^4.14.191":
+  version "4.14.191"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.191.tgz#09511e7f7cba275acd8b419ddac8da9a6a79e2fa"
+  integrity sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==
+
 "@types/node@*":
   version "18.7.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.14.tgz#0fe081752a3333392d00586d815485a17c2cf3c9"
@@ -7989,11 +7994,6 @@ regjsparser@^0.8.2:
   integrity sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==
   dependencies:
     jsesc "~0.5.0"
-
-remeda@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/remeda/-/remeda-1.3.0.tgz#6dc642187e08ead2265e8c7f8517a16a69e325ce"
-  integrity sha512-DJkLBUzi0dEigDuyPtVe50aNzQq8EBQOintPaxvzwSNreXOGsRnvfGiK+cTsY+nUgGCBrcFxcvH8MIg2skfIZA==
 
 remove-markdown@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
moving from remeda to lodash for consistency 🤔 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.5.1--canary.36.3839055487.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@3.5.1--canary.36.3839055487.0
  # or 
  yarn add @artsy/palette-mobile@3.5.1--canary.36.3839055487.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
