### PR TITLE
fix: Button was missing the restProps

### DIFF
--- a/lib/elements/Button/Button.tsx
+++ b/lib/elements/Button/Button.tsx
@@ -1,16 +1,13 @@
 import { useState } from "react"
-import { PressableProps, TextStyle, GestureResponderEvent, Pressable } from "react-native"
+import { PressableProps, GestureResponderEvent, Pressable } from "react-native"
 import Haptic, { HapticFeedbackTypes } from "react-native-haptic-feedback"
 import Animated, {
-  interpolateColor,
-  runOnJS,
   useAnimatedReaction,
   useAnimatedStyle,
-  useDerivedValue,
   useSharedValue,
   withTiming,
 } from "react-native-reanimated"
-import { useColor, Box, BoxProps, Flex, Spacer, Color, ColorStrict } from "../.."
+import { useColor, Box, BoxProps, Flex, Spacer } from "../.."
 import { MeasuredView, ViewMeasurements } from "../../utils/MeasuredView"
 import { Spinner } from "../Spinner"
 import { Text, useTextStyleForPalette } from "../Text"
@@ -179,6 +176,7 @@ export const Button = ({
       testOnly_pressed={testOnly_pressed}
     >
       <Animated.View
+        {...restProps}
         style={[
           {
             height: height,

--- a/lib/elements/Button/colors.tsx
+++ b/lib/elements/Button/colors.tsx
@@ -1,4 +1,3 @@
-import { SharedValue } from "react-native-reanimated"
 import { ButtonProps, useColor } from "../.."
 import { NoUndefined } from "../../utils/types"
 


### PR DESCRIPTION
quick fix
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.1.0--canary.52.4135464888.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@8.1.0--canary.52.4135464888.0
  # or 
  yarn add @artsy/palette-mobile@8.1.0--canary.52.4135464888.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
