### PR TITLE
feat: typescript magic, allowing negative DS values, and 0 and auto

### DIFF
--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -25,14 +25,11 @@ const {
 
 export type SpacingUnitPixelValue = `${number}px` & {} // for things like `12px`
 export type SpacingUnitDSValueNumber = SpacingUnitV3Numbers
+export type SpacingUnitDSValueNumberNegative = Neg<SpacingUnitDSValueNumber>
+export type SpacingUnitDSValue = SpacingUnitDSValueNumber | SpacingUnitDSValueNumberNegative
+type SpacingUnitSpecialValue = 0 | "0px" | "auto"
 
-type SpacingUnitDSValueNumberNegativeString = `-${SpacingUnitDSValueNumber}` // this should *NOT* be used or exported. it is only an intermediary type for the next line.
-export type SpacingUnitDSValueNumberNegative = ParseNumber<SpacingUnitDSValueNumberNegativeString>
-
-export type SpacingUnit =
-  | SpacingUnitDSValueNumber
-  | SpacingUnitDSValueNumberNegative
-  | SpacingUnitPixelValue
+export type SpacingUnit = SpacingUnitDSValue | SpacingUnitPixelValue | SpacingUnitSpecialValue
 
 // this function is converting the space values that come from palette-tokens
 // from a string `"120px"` to a number `120`, and the key values
@@ -256,8 +253,12 @@ export type SpacingUnitsTheme = { space: Record<SpacingUnit, any> }
 export type ColorsTheme = { colors: Record<Color, any> }
 
 // This is some funky typescript to help us flip the type `SpacingUnitDSValueNumber` to negative numbers.
-type ParseNumber<T extends `-${number}`> = T extends any
-  ? T extends `${infer Digit extends number}`
-    ? Digit
-    : never
-  : never
+type Neg<T extends number> = T extends 0
+  ? 0
+  : `-${T}` extends `${infer U extends number}`
+  ? U
+  : `${T}` extends `-${infer U extends number}`
+  ? U
+  : Extract<[1e999, -1e999] | [-1e999, 1e999] | [0, 0], [T, unknown]> extends [T, infer U]
+  ? U
+  : T

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-native-svg": "*"
   },
   "devDependencies": {
+    "@artsy/auto-config": "1.2.0",
     "@auto-it/all-contributors": "10.38.5",
     "@auto-it/first-time-contributor": "10.38.5",
     "@babel/core": "7.20.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,11 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@artsy/auto-config@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@artsy/auto-config/-/auto-config-1.2.0.tgz#62a237ca3a058f1b91e5b8a12abebae0ddc5bd2f"
+  integrity sha512-6zGlvqELl4XhqMajJxfgHaY3m5YhZK5FwkxlouJKSb0Su301bzXaPUxKjzj9X147YHJUyrRLSAruzVtj1Gr42Q==
+
 "@artsy/palette-tokens@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@artsy/palette-tokens/-/palette-tokens-4.0.1.tgz#ef171c0449f3c0a1c0765253a06beec160b0eed1"


### PR DESCRIPTION
a bit more flexibility
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.0--canary.53.4145733196.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@8.2.0--canary.53.4145733196.0
  # or 
  yarn add @artsy/palette-mobile@8.2.0--canary.53.4145733196.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
