### PR TITLE
fix: Flex can now have ref without type errors

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -42,6 +42,7 @@ const getStories = () => {
     require("../lib/elements/Skeleton/Skeleton.stories.tsx"),
     require("../lib/elements/Touchable/Touchable.stories.tsx"),
     require("../lib/molecules/MenuItem.stories.tsx"),
+    require("../lib/space.stories.tsx"),
     require("../lib/svgs/icons.stories.tsx"),
   ]
 }

--- a/lib/atoms/Box/Box.stories.tsx
+++ b/lib/atoms/Box/Box.stories.tsx
@@ -1,5 +1,7 @@
+import { useRef } from "react"
+import { View } from "react-native"
 import { List } from "../../storybookHelpers"
-import { Box } from "../Box"
+import { Box, BoxProps } from "../Box"
 
 export default {
   title: "Box",
@@ -26,3 +28,15 @@ export const Styled = () => (
     />
   </List>
 )
+
+export const RegularViewProps = () => {
+  const r = useRef<View>(null)
+  return (
+    <Box
+      px={1}
+      backgroundColor="red100"
+      onLayout={(e) => console.log(e.nativeEvent.layout)}
+      ref={r}
+    />
+  )
+}

--- a/lib/atoms/Flex/Flex.tsx
+++ b/lib/atoms/Flex/Flex.tsx
@@ -1,9 +1,11 @@
+import { forwardRef } from "react"
+import { View } from "react-native"
 import { Box, BoxProps } from "../Box"
 
 export type FlexProps = BoxProps
 
-export const Flex = ({ backgroundColor, ...restProps }: FlexProps) => (
-  <Box backgroundColor={backgroundColor ?? "transparent"} {...restProps} />
-)
+export const Flex = forwardRef<View, FlexProps>(({ backgroundColor, ...restProps }, ref) => (
+  <Box backgroundColor={backgroundColor ?? "transparent"} {...restProps} ref={ref} />
+))
 
 Flex.displayName = "Flex"

--- a/lib/elements/CollapsibleMenuItem/CollapsibleMenuItem.tsx
+++ b/lib/elements/CollapsibleMenuItem/CollapsibleMenuItem.tsx
@@ -68,7 +68,6 @@ export const CollapsibleMenuItem = forwardRef<
     )
 
     return (
-      // @ts-expect-error
       <Flex ref={componentRef} collapsable={false}>
         <Touchable
           onPress={() => {

--- a/lib/space.stories.tsx
+++ b/lib/space.stories.tsx
@@ -1,0 +1,31 @@
+import { bullet, Box, useSpace, Text, SpacingUnitDSValueNumber } from "."
+import { List } from "./storybookHelpers"
+
+const SpaceLine = ({ space: theSpace }: { space: SpacingUnitDSValueNumber }) => {
+  const space = useSpace()
+  return (
+    <Box>
+      <Box width={space(theSpace)} borderBottomWidth={1} borderColor="black" marginBottom="4px" />
+      <Text color="black">
+        {typeof theSpace === "string"
+          ? `${theSpace}`
+          : `${theSpace} ${bullet} ${space(theSpace as any)}px`}
+      </Text>
+    </Box>
+  )
+}
+
+export default {
+  title: "space",
+}
+
+export const SpacingUnits = () => (
+  <List style={{ marginLeft: 50 }} contentContainerStyle={{ alignItems: "flex-start" }}>
+    <SpaceLine space={0.5} />
+    <SpaceLine space={1} />
+    <SpaceLine space={2} />
+    <SpaceLine space={4} />
+    <SpaceLine space={6} />
+    <SpaceLine space={12} />
+  </List>
+)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "events": "^3.3.0",
     "lodash": "^4.17.21",
     "react-nanny": "^2.15.0",
-    "styled-components": "^5.3.6",
     "styled-system": "^5.1.5"
   },
   "peerDependenciesComments": [
@@ -45,7 +44,8 @@
     "react-native-haptic-feedback": "*",
     "react-native-linear-gradient": "*",
     "react-native-reanimated": "*",
-    "react-native-svg": "*"
+    "react-native-svg": "*",
+    "styled-components": ">= 5"
   },
   "devDependencies": {
     "@artsy/auto-config": "1.2.0",
@@ -102,6 +102,7 @@
     "react-test-renderer": "18.2.0",
     "rimraf": "4.1.2",
     "rn-flipper-async-storage-advanced": "1.0.4",
+    "styled-components": "^5.3.6",
     "typescript": "4.9.5"
   },
   "files": [


### PR DESCRIPTION
Flex types were missing the ref, now its fixed.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.3.1--canary.54.4166102610.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@8.3.1--canary.54.4166102610.0
  # or 
  yarn add @artsy/palette-mobile@8.3.1--canary.54.4166102610.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
