### PR TITLE
feat: less confusing name for darkmode support

### DIFF
--- a/lib/Theme.tsx
+++ b/lib/Theme.tsx
@@ -1,23 +1,25 @@
 import { useContext } from "react"
 import { isString } from "lodash"
 import { ThemeContext, ThemeProvider } from "styled-components/native"
-import { AllThemesType, ThemeV3Type, ThemeV5Type, THEMES } from "./tokens"
+import { AllThemesType, ThemeV3Type, ThemeV3WithDarkModeSupportType, THEMES } from "./tokens"
 
-const figureOutTheme = (theme: keyof typeof THEMES | AllThemesType): ThemeV3Type | ThemeV5Type => {
+const figureOutTheme = (
+  theme: keyof typeof THEMES | AllThemesType
+): ThemeV3Type | ThemeV3WithDarkModeSupportType => {
   if (!isString(theme)) {
     return theme
   }
 
-  if (theme === "v5light") return THEMES.v5light
+  if (theme === "v3light") return THEMES.v3light
 
-  if (theme === "v5dark") return THEMES.v5dark
+  if (theme === "v3dark") return THEMES.v3dark
 
   return THEMES.v3
 }
 
 export const Theme = ({
   children,
-  theme = "v5light",
+  theme = "v3light",
 }: {
   children?: React.ReactNode
   theme?: keyof typeof THEMES | AllThemesType

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -43,7 +43,7 @@ export const useTheme = (): {
     )
   }
 
-  const defaultTheme = THEMES.v5light
+  const defaultTheme = THEMES.v3light
   const theme = maybeTheme ?? defaultTheme
 
   return {

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -163,18 +163,18 @@ export type ThemeV3Type = {
   fonts: { sans: { regular: string; italic: string; medium: string; mediumItalic: string } }
   textTreatments: Record<TextVariantV3, TextTreatment>
 }
-export type ThemeV5Type = {
+export type ThemeV3WithDarkModeSupportType = {
   space: Record<SpacingUnitV3Numbers, `${number}px`>
   colors: Record<ColorStrict, string>
   fonts: { sans: { regular: string; italic: string; medium: string; mediumItalic: string } }
   textTreatments: Record<TextVariantV3, TextTreatment>
 }
-export type AllThemesType = ThemeV3Type & ThemeV5Type
+export type AllThemesType = ThemeV3Type & ThemeV3WithDarkModeSupportType
 
 export const THEMES: {
   v3: ThemeV3Type
-  v5light: ThemeV5Type
-  v5dark: ThemeV5Type
+  v3light: ThemeV3WithDarkModeSupportType
+  v3dark: ThemeV3WithDarkModeSupportType
 } = {
   v3: {
     ...mobileUsefulTHEME_V3,
@@ -190,7 +190,7 @@ export const THEMES: {
     },
     textTreatments: fixTextTreatments(textVariantsWithUnits),
   },
-  get v5light() {
+  get v3light() {
     return {
       ...this.v3,
       colors: {
@@ -218,7 +218,7 @@ export const THEMES: {
       },
     }
   },
-  get v5dark() {
+  get v3dark() {
     return {
       ...this.v3,
       colors: {

--- a/lib/tokens.ts
+++ b/lib/tokens.ts
@@ -1,7 +1,7 @@
 /**
  * All of the config for the Artsy theming system, based on the
  * design system from our design team:
- * https://www.notion.so/artsy/Master-Library-810612339f474d0997fe359af4285c56
+ * https://www.figma.com/file/gZNkyqLT8AU3T61tluVJyB/Artsy-3.1-Design-System
  */
 
 import { THEME_V3 } from "@artsy/palette-tokens"

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -7,7 +7,7 @@ import { Appearance } from "react-native"
 import { Flex, Theme, Text, LinkText } from "../../lib"
 
 export const withTheme = (Story) => (
-  <Theme theme="v5light">
+  <Theme theme="v3light">
     <Text color="red">aaww</Text>
     <Story />
   </Theme>
@@ -36,7 +36,7 @@ export const withDarkModeSwitcher: DecoratorFunction<ReactNode> = (story) => {
   }, [])
 
   const isDarkMode = mode === "dark" || (mode === "system" && systemMode === "dark")
-  const theme = isDarkMode ? "v5dark" : "v5light"
+  const theme = isDarkMode ? "v3dark" : "v3light"
 
   return (
     <Theme theme={theme}>


### PR DESCRIPTION
quick rename of the themes

## Release Notes

Some renames:
- `v5light` -> `v3light`
- `v5dark` -> `v3dark`

`v5` was a temporary name, picked to make sure we can try dark mode without messing with v3 (or a potential v4 while we figure stuff out). Now that things are set, we can use `v3` for the non-dark-mode DS, and `v3light` and `v3dark` for v3 with added role name layer (like `background` and `onBackground` etc).

In the future, we will either have a `vX` for a non-dark-mode and `vXlight` and `vXdark`, or if the design team decides to incorporate dark mode, then we will only have a `vXlight` and `vXdark`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.7.5--canary.59.4179384877.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@8.7.5--canary.59.4179384877.0
  # or 
  yarn add @artsy/palette-mobile@8.7.5--canary.59.4179384877.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
