### PR TITLE
fix: provider error and text prep

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -39,6 +39,7 @@ const getStories = () => {
     require("../lib/elements/Separator/Separator.stories.tsx"),
     require("../lib/elements/Skeleton/Skeleton.stories.tsx"),
     require("../lib/elements/Spacer/Spacer.stories.tsx"),
+    require("../lib/elements/Text/Text.stories.tsx"),
     require("../lib/elements/Touchable/Touchable.stories.tsx"),
     require("../lib/svgs/icons.stories.tsx"),
     require("../lib/utils/colors.stories.tsx"),

--- a/lib/Theme.tsx
+++ b/lib/Theme.tsx
@@ -1,4 +1,3 @@
-import { isString } from "lodash"
 import { ThemeProvider } from "styled-components/native"
 import { ThemeType, ThemeWithDarkModeType, THEMES } from "./tokens"
 

--- a/lib/elements/Button/Button.tests.tsx
+++ b/lib/elements/Button/Button.tests.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen } from "@testing-library/react-native"
+import { fireEvent } from "@testing-library/react-native"
 import { Button } from "."
 import { Spinner } from ".."
 import { renderWithWrappers } from "../../utils/tests/renderWithWrappers"

--- a/lib/elements/Text/LinkText.tsx
+++ b/lib/elements/Text/LinkText.tsx
@@ -1,6 +1,5 @@
-import styled from "styled-components/native"
-import { Text } from "./Text"
+import { Text, TextProps } from "./Text"
 
-export const LinkText = styled(Text)`
-  text-decoration-line: underline;
-`
+export const LinkText = ({ style, ...props }: TextProps) => (
+  <Text {...props} style={[style, { textDecorationLine: "underline" }]} />
+)

--- a/lib/elements/Text/Text.stories.tsx
+++ b/lib/elements/Text/Text.stories.tsx
@@ -1,0 +1,106 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react-native"
+import { Platform, Text as RNText, TextStyle, View } from "react-native"
+import { LinkText, Text, TextProps } from "."
+import { DataList, List } from "../../storybook/helpers"
+import { Box } from "../Box"
+import { Flex } from "../Flex"
+
+const TextMeta: ComponentMeta<typeof Text> = {
+  title: "Theme/Text",
+  component: Text,
+}
+export default TextMeta
+type TextStory = ComponentStory<typeof Text>
+
+const variants: Array<TextProps["variant"]> = ["xs", "sm", "md", "lg", "xl", "xxl"]
+export const Variants: TextStory = () => (
+  <DataList
+    data={variants}
+    renderItem={({ item: variant }) => <Text variant={variant}>{variant} ~~ This is a text.</Text>}
+  />
+)
+
+export const VariantsInBoxes: TextStory = () => (
+  <DataList
+    data={variants}
+    renderItem={({ item: variant }) => (
+      <Box borderWidth={1} borderColor="black" width={100}>
+        <Text variant={variant}>{variant} ~~ This is a text.</Text>
+      </Box>
+    )}
+  />
+)
+
+export const BasicProps: TextStory = () => (
+  <List>
+    <Text>regular ~~ This is a text.</Text>
+    <LinkText>LinkText.</LinkText>
+    <Text caps>caps ~~ This is a text.</Text>
+    <Text italic>italics ~~ This is a text.</Text>
+    <Text caps italic>
+      caps italics ~~ This is a text.
+    </Text>
+    <Text weight="medium">weight: medium ~~ This is a text.</Text>
+    <Text maxWidth>maxwidth ~~ This is a text.</Text>
+  </List>
+)
+
+export const Misc: TextStory = () => (
+  <List>
+    <View style={{ borderWidth: 1, borderColor: "black" }}>
+      <Text pl={2} mb={4} mr={80} color="red" backgroundColor="orange">
+        Testing the other props
+      </Text>
+    </View>
+    <View />
+  </List>
+)
+
+// this is useful for making sure our custom fonts are rendering at the same height for ios and android
+export const FontCenteringRaw: TextStory = () => {
+  const style: TextStyle = { borderWidth: 1, borderColor: "black", fontSize: 16, lineHeight: 16 }
+  const systemFontStyle: TextStyle =
+    Platform.OS === "android" ? { textAlignVertical: "bottom" } : {} // this we add in our Text in palette-eigen
+  const unicaFontStyle: TextStyle = Platform.OS === "android" ? { textAlignVertical: "center" } : {} // this we add in our Text in palette-eigen
+
+  return (
+    <Flex flexDirection="row" flex={1}>
+      <Flex flex={1}>
+        <RNText>System font</RNText>
+        <List>
+          <RNText style={[style, systemFontStyle]}>regular TEXT.</RNText>
+          <RNText style={[style, systemFontStyle]}>ALL CAPS text.</RNText>
+        </List>
+      </Flex>
+
+      <Flex width="1px" height="100%" borderWidth={1} borderColor="black" />
+
+      <Flex flex={1}>
+        <RNText>Unica custom font</RNText>
+        <List>
+          <RNText style={[style, { fontFamily: "Unica77LL-Regular" }, unicaFontStyle]}>
+            regular TEXT.
+          </RNText>
+          <RNText style={[style, { fontFamily: "Unica77LL-Regular" }, unicaFontStyle]}>
+            ALL CAPS text.
+          </RNText>
+        </List>
+      </Flex>
+    </Flex>
+  )
+}
+
+// this is useful for making sure our custom fonts are rendering at the same height for ios and android
+export const FontCenteringPalette: TextStory = () => {
+  const style: TextStyle = { borderWidth: 1, borderColor: "black", fontSize: 16, lineHeight: 16 }
+
+  return (
+    <Flex flex={1}>
+      <Text>System font</Text>
+      <List>
+        <Text style={style}>regular TEXT.</Text>
+        <Text style={style}>ALL CAPS text.</Text>
+      </List>
+    </Flex>
+  )
+}

--- a/lib/elements/Text/Text.tests.ts
+++ b/lib/elements/Text/Text.tests.ts
@@ -1,0 +1,11 @@
+import { endash, range } from "../../utils/text"
+
+describe("Text", () => {
+  it("uses endash in ranges", () => {
+    const usingHelper = range("10", "20")
+    const usingEndash = `10 ${endash} 20`
+    expect(usingHelper).toEqual(usingEndash)
+    expect(usingHelper).toEqual("10 – 20") // endash
+    expect(usingHelper).not.toEqual("10 - 20") // minus
+  })
+})

--- a/lib/elements/Text/Text.tsx
+++ b/lib/elements/Text/Text.tsx
@@ -25,6 +25,7 @@ export interface TextProps extends RNTextProps, InnerStyledTextProps {
   weight?: "regular" | "medium"
   maxChars?: number
   underline?: boolean
+  maxWidth?: boolean
 }
 
 export const Text = forwardRef(
@@ -36,6 +37,7 @@ export const Text = forwardRef(
       caps,
       weight = "regular",
       underline = false,
+      maxWidth,
       style,
       children,
       ...restProps
@@ -54,6 +56,7 @@ export const Text = forwardRef(
           ...nativeTextStyle,
           { textAlignVertical: "center" }, // android renders text higher by default, so we bring it down to be consistent with ios
           { textDecorationLine: !!underline ? "underline" : "none" },
+          !!maxWidth ? { width: "100%", maxWidth: 600, alignSelf: "center" } : {},
           style, // keep last so we can override
         ]}
         fontFamily={fontFamily}

--- a/lib/svgs/Icon.tsx
+++ b/lib/svgs/Icon.tsx
@@ -1,6 +1,6 @@
 import { PixelRatio } from "react-native"
 import Svg, { SvgProps } from "react-native-svg"
-import styled from "styled-components"
+import styled from "styled-components/native"
 import {
   left,
   LeftProps,

--- a/lib/utils/hooks/useTheme.tsx
+++ b/lib/utils/hooks/useTheme.tsx
@@ -1,6 +1,6 @@
 import { SpacingUnit } from "@artsy/palette-tokens/dist/themes/v3"
 import { useContext } from "react"
-import { ThemeContext } from "styled-components"
+import { ThemeContext } from "styled-components/native"
 import { AllThemesType, THEMES, ThemeType, ThemeWithDarkModeType } from "../../tokens"
 import { Color, ColorDSValue } from "../../types"
 


### PR DESCRIPTION
text prep for eigen, and provider fix for test error
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.0.3--canary.67.4204106221.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@10.0.3--canary.67.4204106221.0
  # or 
  yarn add @artsy/palette-mobile@10.0.3--canary.67.4204106221.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
