### PR TITLE
feat: add noTopSafe noBottomSafe props to screen component

### DIFF
--- a/src/elements/Screen/Screen.tsx
+++ b/src/elements/Screen/Screen.tsx
@@ -29,9 +29,11 @@ interface ScreenContextValue {
   setOptions: (opts: Partial<ScreenContextState>) => void
 }
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const ScreenContext = createContext<ScreenContextValue>(null!)
 function useScreenContext() {
   const context = useContext(ScreenContext)
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
   if (!context) {
     throw new Error("useScreenContext must be used within a Screen")
   }
@@ -167,12 +169,16 @@ interface BodyProps extends Partial<Pick<FlexProps, "backgroundColor">> {
   children?: ReactNode
   scroll?: boolean
   nosafe?: boolean
+  noTopSafe?: boolean
+  noBottomSafe?: boolean
   fullwidth?: boolean
 }
 
 const Body = ({
   scroll = false,
   nosafe = false,
+  noTopSafe = false,
+  noBottomSafe = false,
   fullwidth = false,
   children,
   ...restFlexProps
@@ -181,15 +187,15 @@ const Body = ({
   const bottomView = getChildrenByType(children, Screen.BottomView)
   const { options } = useScreenContext()
   const insets = useSafeAreaInsets()
-  const withTopSafeArea = options.handleTopSafeArea && !nosafe
-  const withBottomSafeArea = !nosafe
+  const withTopSafeArea = options.handleTopSafeArea && !noTopSafe
+  const withBottomSafeArea = !noBottomSafe
 
   return (
     <>
       <Flex
         flex={1}
-        mt={withTopSafeArea ? `${insets.top}px` : undefined}
-        mb={withBottomSafeArea ? `${insets.bottom}px` : undefined}
+        mt={nosafe || withTopSafeArea ? `${insets.top}px` : undefined}
+        mb={nosafe || withBottomSafeArea ? `${insets.bottom}px` : undefined}
         {...restFlexProps}
       >
         <Wrap if={scroll}>


### PR DESCRIPTION
## Description

Adds `noTopSafe` and `noBottomSafe` props to <Screen.Body> component to be able to use only one and not being limited to only use `nosafe`


The reasoning behind this is that we came across an edge case in [eigen](https://github.com/artsy/eigen/blob/main/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabs.tsx#L28) where the `nosafe` wasn't working correctly and we changed the inside eigen palette component.

This PR ensures that when moving to use `palette-mobile` we won't break the ui
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.4--canary.75.4551718796.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@11.0.4--canary.75.4551718796.0
  # or 
  yarn add @artsy/palette-mobile@11.0.4--canary.75.4551718796.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
