### PR TITLE
fix: replace spacerprops with flexprops

### DIFF
--- a/src/elements/EntityHeader/EntityHeader.tsx
+++ b/src/elements/EntityHeader/EntityHeader.tsx
@@ -1,10 +1,9 @@
 import { bullet } from "../../utils/text"
 import { Avatar } from "../Avatar"
-import { Flex } from "../Flex"
-import { SpacerProps } from "../Spacer"
+import { Flex, FlexProps } from "../Flex"
 import { Text } from "../Text"
 
-interface EntityHeaderProps extends SpacerProps {
+interface EntityHeaderProps extends FlexProps {
   smallVariant?: boolean
   href?: string
   imageUrl?: string


### PR DESCRIPTION
# Description

while migrating entityheader noticed that it extends SpacerProps that doesn't make sense since all the props that we pass go to Flex. 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.7--canary.80.4627106106.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@11.0.7--canary.80.4627106106.0
  # or 
  yarn add @artsy/palette-mobile@11.0.7--canary.80.4627106106.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
