### PR TITLE
chore(scripts): rename yarn local-palette-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start": "react-native start",
     "start:reset-cache": "react-native start --reset-cache",
     "storybook-watcher": "sb-rn-watcher",
-    "sync-after-change": "./scripts/sync-after-change",
+    "local-palette-dev": "./scripts/sync-after-change",
     "test": "jest",
     "type-check": "tsc --noEmit",
     "prepare": "husky install"


### PR DESCRIPTION
This renames the local palette development script to `yarn local-palette-dev`. Going to also update Eigen to the same so that things are easier to remember. (The underlying script that it points at remains the same, though, to better describe whats happening.)

cc @artsy/mobile-platform 