### PR TITLE
fix(button): fix worklet crash error in eigen

### DIFF
--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -152,6 +152,8 @@ export const Button = ({
   })
 
   const textAnim = useAnimatedStyle(() => {
+    "worklet"
+
     const colors = colorsForVariantAndState[variant]
     if (loading) {
       return { color: "rgba(0, 0, 0, 0)" }
@@ -270,6 +272,8 @@ const useStateWithProp = (
     setState(!!prop)
   }, [prop])
   const stateV = useDerivedValue(() => {
+    "worklet"
+
     if (!!state) {
       return 1
     }


### PR DESCRIPTION
This is an odd one. After updating the button, noticed this screen appearing in Eigen (only when _not_ debugging; with the debugger on, it doesn't appear): 

<img width="387" alt="Screenshot 2023-04-14 at 10 59 17 AM" src="https://user-images.githubusercontent.com/236943/232128432-1592d301-dc61-42a3-ba61-8665c5524e8d.png">

The stack trace didn't leave any real info as to where this was coming from but [this pr](https://github.com/artsy/palette-mobile/pull/87/files#diff-ae26129b6f7e71c289c0256844d6aa8039ef2a4c343e09a9e1ecb88a271a853bL272) suggested that it might be coming from Button. 

Running `yarn local-palette-dev` in both repos, I was able to see that after adding "worklet" to two offending spots, the problem went away. 

A natural follow-up here would be to simplify this button a bit and get Moti in for animation. 

cc @artsy/mobile-platform 