### PR TITLE
build(deps): followup on rn upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'cocoapods', '~> 1.11', '>= 1.11.2'
+gem 'cocoapods', '>= 1.11.3'
 gem "fastlane", "~> 2.210"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.11, >= 1.11.2)
+  cocoapods (>= 1.11.3)
   fastlane (~> 2.210)
 
 BUNDLED WITH

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "setup:artsy": "./scripts/download-fonts",
     "start:reset-cache": "react-native start --reset-cache",
     "start": "react-native start",
-    "../../storybook-watcher": "sb-rn-watcher",
+    "storybook-watcher": "sb-rn-watcher",
     "test": "jest",
     "type-check": "tsc --noEmit"
   },


### PR DESCRIPTION
## Description

Noticed that in https://github.com/artsy/palette-mobile/pull/91 we also changed a script in `package.json`, this pr fixes that and also updates cocoapods as per [react native migration guide](https://react-native-community.github.io/upgrade-helper/?from=0.70.7&to=0.70.8)