### PR TITLE
fix(import): fix super relative imports

### DIFF
--- a/src/elements/Button/FollowButton.tsx
+++ b/src/elements/Button/FollowButton.tsx
@@ -1,5 +1,5 @@
-import { Button, ButtonProps } from "."
 import { CheckIcon } from "../../svgs/CheckIcon"
+import { Button, ButtonProps } from "../Button"
 
 type FollowButtonProps = Omit<
   ButtonProps,

--- a/src/elements/Button/LinkButton.tsx
+++ b/src/elements/Button/LinkButton.tsx
@@ -1,5 +1,5 @@
-import { Touchable } from ".."
 import { TextProps, Text } from "../Text"
+import { Touchable } from "../Touchable"
 
 export const LinkButton = (props: TextProps) => (
   <Touchable onPress={props.onPress}>


### PR DESCRIPTION
Consuming apps (specifically _jest_, in consuming apps) don't like imports that are unspecific, and will lead to strange import behavior. This fixes that in the newly imported button. 

cc @artsy/mobile-platform 