### PR TITLE
fix: crash in eigen caused by tooltip

### DIFF
--- a/src/elements/ToolTip/ToolTipFlyout.tsx
+++ b/src/elements/ToolTip/ToolTipFlyout.tsx
@@ -30,14 +30,17 @@ export const ToolTipFlyout: React.FC<Props> = ({
   const initialBoxDimensions = { height: 0, width: 0 }
   const boxDimensions = useSharedValue(initialBoxDimensions)
 
-  const animationStyle = useAnimatedStyle(() => ({
-    height: withTiming(boxDimensions.value.height, {
-      duration: 500,
-    }),
-    width: withTiming(boxDimensions.value.width, {
-      duration: 500,
-    }),
-  }))
+  const animationStyle = useAnimatedStyle(() => {
+    "worklet"
+    return {
+      height: withTiming(boxDimensions.value.height, {
+        duration: 500,
+      }),
+      width: withTiming(boxDimensions.value.width, {
+        duration: 500,
+      }),
+    }
+  })
 
   useEffect(() => {
     if (text) {


### PR DESCRIPTION
this is causing a crash in eigen when entering myCollection with a tooltip showing.

before:
https://user-images.githubusercontent.com/49686530/236051985-97273ca9-8daa-4b43-8946-7f8c8d641061.mov

after:
https://user-images.githubusercontent.com/49686530/236051997-2b6c8648-d614-403b-9944-fa163dd43c5b.mov