### PR TITLE
fix: no more implicit returns in reanimated hooks

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -31,7 +31,7 @@ const getStories = () => {
     require("../src/elements/Avatar/Avatar.stories.tsx"),
     require("../src/elements/BackButton/BackButton.stories.tsx"),
     require("../src/elements/Box/Box.stories.tsx"),
-    require("../src/elements/Button/Button.stories.tsx"),
+    require("../src/elements/ButtonNew/Button.stories.tsx"),
     require("../src/elements/Checkbox/Checkbox.stories.tsx"),
     require("../src/elements/Collapse/Collapse.stories.tsx"),
     require("../src/elements/CollapsibleMenuItem/CollapsibleMenuItem.stories.tsx"),

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
 
+ruby '>= 2.6.10'
+
 gem 'cocoapods', '>= 1.11.3'
 gem "fastlane", "~> 2.210"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,5 +280,8 @@ DEPENDENCIES
   cocoapods (>= 1.11.3)
   fastlane (~> 2.210)
 
+RUBY VERSION
+   ruby 2.7.5p203
+
 BUNDLED WITH
    2.3.23

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -75,7 +75,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.70.7)
+  - hermes-engine (0.70.8)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.07.22.00):
@@ -604,7 +604,7 @@ SPEC CHECKSUMS:
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  hermes-engine: 566e656aa95456a3f3f739fd76ea9a9656f2633f
+  hermes-engine: 0b19f33a9c2ec1dbdede3232606eeb1101db4cec
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda

--- a/src/elements/ButtonNew/Button.tsx
+++ b/src/elements/ButtonNew/Button.tsx
@@ -88,9 +88,13 @@ export const Button = ({
 
   const pressAnimationProgress = useSharedValue(0)
   useAnimatedReaction(
-    () => pressedV.value,
+    () => {
+      return pressedV.value
+    },
     (pressedVal) => {
-      pressAnimationProgress.value = withTiming(pressedVal, { duration: ANIMATION_DURATION })
+      return (pressAnimationProgress.value = withTiming(pressedVal, {
+        duration: ANIMATION_DURATION,
+      }))
     }
   )
 

--- a/src/elements/ProgressBar/ProgressBar.tsx
+++ b/src/elements/ProgressBar/ProgressBar.tsx
@@ -26,7 +26,9 @@ export const ProgressBar = ({
   const color = useColor()
   const width = useSharedValue("0%")
   const progress = clamp(unclampedProgress, 0, 100)
-  const progressAnim = useAnimatedStyle(() => ({ width: width.value }))
+  const progressAnim = useAnimatedStyle(() => {
+    return { width: width.value }
+  })
 
   const [onCompletionCalled, setOnCompletionCalled] = useState(false)
 

--- a/src/elements/Skeleton/Skeleton.tsx
+++ b/src/elements/Skeleton/Skeleton.tsx
@@ -23,7 +23,9 @@ import { Text, TextProps } from "../Text"
 export const Skeleton: FC<{ children: ReactNode }> = ({ children }) => {
   const opacity = useSharedValue(0.5)
   opacity.value = withRepeat(withTiming(1, { duration: 1000, easing: Easing.ease }), -1, true)
-  const fadeLoopAnim = useAnimatedStyle(() => ({ opacity: opacity.value }), [])
+  const fadeLoopAnim = useAnimatedStyle(() => {
+    return { opacity: opacity.value }
+  }, [])
 
   return <Animated.View style={fadeLoopAnim}>{children}</Animated.View>
 }


### PR DESCRIPTION
We believe that implicit returns are not playing well with babel resulting in our js functions in hooks not being converted to "worklets" which causes crashes when reanimated tries to run them on the wrong thread. 

https://artsy.slack.com/archives/C02NAJ2CGLW/p1683148878257549

props @gkartalis @damassi for sleuthing

tangential: Adds a couple missed react native upgrade changes, Hermes-engine failing pod install and gem and ruby settings might not be necessary but good to keep in sync. Button story path broke when we brought back old button.