### PR TITLE
fix: mark all reanimated hooks functions as worklets explicitly

### DIFF
--- a/src/elements/ButtonNew/Button.tsx
+++ b/src/elements/ButtonNew/Button.tsx
@@ -134,6 +134,7 @@ export const Button = ({
   const colorsForVariantAndState = useColorsForVariantAndState()
 
   const containerColorsAnim = useAnimatedStyle(() => {
+    "worklet"
     const colors = colorsForVariantAndState[variant]
     if (disabled) {
       return {
@@ -157,7 +158,6 @@ export const Button = ({
 
   const textAnim = useAnimatedStyle(() => {
     "worklet"
-
     const colors = colorsForVariantAndState[variant]
     if (loading) {
       return { color: "rgba(0, 0, 0, 0)" }

--- a/src/elements/ProgressBar/ProgressBar.tsx
+++ b/src/elements/ProgressBar/ProgressBar.tsx
@@ -27,6 +27,7 @@ export const ProgressBar = ({
   const width = useSharedValue("0%")
   const progress = clamp(unclampedProgress, 0, 100)
   const progressAnim = useAnimatedStyle(() => {
+    "worklet"
     return { width: width.value }
   })
 

--- a/src/elements/Skeleton/Skeleton.tsx
+++ b/src/elements/Skeleton/Skeleton.tsx
@@ -24,6 +24,7 @@ export const Skeleton: FC<{ children: ReactNode }> = ({ children }) => {
   const opacity = useSharedValue(0.5)
   opacity.value = withRepeat(withTiming(1, { duration: 1000, easing: Easing.ease }), -1, true)
   const fadeLoopAnim = useAnimatedStyle(() => {
+    "worklet"
     return { opacity: opacity.value }
   }, [])
 


### PR DESCRIPTION
We are continuing to see crashes + red screens due to these functions, in theory this should not be necessary: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/worklets/#using-hooks
But something seems to be broken with our setup. While we investigate it should be safe to mark these explicitly as workouts since that is what they should be anyway.

Follow-up:
Once we figure out what is broken and fix it or upgrade to 3 we should be able to get rid of this