### PR TITLE
fix(header): Make expand

### DIFF
--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -81,7 +81,7 @@ export const Header: React.FC<HeaderProps> = ({
     const display = scrollY < NAVBAR_HEIGHT ? "none" : "flex"
 
     return (
-      <>
+      <Flex flex={1} flexDirection="row">
         <Animated.View
           entering={FadeInDown.duration(400).easing(Easing.out(Easing.exp))}
           exiting={FadeOut.duration(400).easing(Easing.out(Easing.exp))}
@@ -96,7 +96,7 @@ export const Header: React.FC<HeaderProps> = ({
             </Text>
           </Flex>
         </Animated.View>
-      </>
+      </Flex>
     )
   }
 


### PR DESCRIPTION
When we removed the empty flex, there was nothing left to expand the center text area across the way for the left and right elements. 