### PR TITLE
fix(tabs): Ensure title content is properly centered 

### DIFF
--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -47,7 +47,7 @@ export const Header: React.FC<HeaderProps> = ({
     }
 
     return (
-      <Flex pr={1}>
+      <Flex pr={1} width={50}>
         {leftElements ? (
           <>{leftElements}</>
         ) : (
@@ -90,7 +90,7 @@ export const Header: React.FC<HeaderProps> = ({
             flex: 1,
           }}
         >
-          <Flex alignItems="center" {...titleProps}>
+          <Flex alignItems="center" width="100%" {...titleProps}>
             <Text variant="md" numberOfLines={1}>
               {title}
             </Text>
@@ -106,7 +106,7 @@ export const Header: React.FC<HeaderProps> = ({
     }
 
     return (
-      <Flex pl={1}>
+      <Flex width={50} alignItems="flex-end">
         <Spacer x={1} />
         {rightElements}
       </Flex>
@@ -122,6 +122,7 @@ export const Header: React.FC<HeaderProps> = ({
       zIndex={ZINDEX.header}
       backgroundColor="background"
       alignItems="center"
+      width="100%"
     >
       <Left />
       <Center />

--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -81,7 +81,7 @@ export const Header: React.FC<HeaderProps> = ({
     const display = scrollY < NAVBAR_HEIGHT ? "none" : "flex"
 
     return (
-      <>
+      <Flex flex={1} flexDirection="row">
         <Animated.View
           entering={FadeInDown.duration(400).easing(Easing.out(Easing.exp))}
           exiting={FadeOut.duration(400).easing(Easing.out(Easing.exp))}
@@ -96,7 +96,7 @@ export const Header: React.FC<HeaderProps> = ({
             </Text>
           </Flex>
         </Animated.View>
-      </>
+      </Flex>
     )
   }
 

--- a/src/elements/Tabs/TabsContainer.tsx
+++ b/src/elements/Tabs/TabsContainer.tsx
@@ -59,9 +59,6 @@ export const TabsContainer: React.FC<TabsContainerProps> = ({
               activeColor={color("onBackground")}
               inactiveColor={color("onBackgroundMedium")}
               labelStyle={{ marginTop: 0 }} // removing the horizonal margin from the lib
-              tabStyle={{
-                marginHorizontal: 10,
-              }} // adding the margin back here
               indicatorStyle={{
                 backgroundColor: color("onBackground"),
                 height: 1,


### PR DESCRIPTION
Addresses [MOPLAT-806] 

Ensures title header is properly centered by introducing widths on the left and right elements. Since these are typically just icons, 50px seems fine for now, but we might need to adjust in the future. 

<img width="439" alt="Screenshot 2023-06-05 at 12 29 48 PM" src="https://github.com/artsy/palette-mobile/assets/236943/ebeaa23a-2919-45c7-91d6-5060f3d8c094">

<img width="425" alt="Screenshot 2023-06-05 at 12 30 08 PM" src="https://github.com/artsy/palette-mobile/assets/236943/4f9d45ba-a14c-42de-9562-5959e457671a">

cc @artsy/mobile-platform 

[MOPLAT-806]: https://artsyproduct.atlassian.net/browse/MOPLAT-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ