### PR TITLE
fix(touchable): underlayColor replace white100 to transparent

### DIFF
--- a/src/elements/Touchable/Touchable.tsx
+++ b/src/elements/Touchable/Touchable.tsx
@@ -57,7 +57,7 @@ export const Touchable: React.FC<TouchableProps> = ({
     </TouchableWithoutFeedback>
   ) : (
     <TouchableHighlight
-      underlayColor={underlayColor ?? color("white100")}
+      underlayColor={underlayColor ?? color("transparent")}
       activeOpacity={0.8}
       {...props}
       onPress={onPressWrapped}

--- a/src/elements/Touchable/Touchable.tsx
+++ b/src/elements/Touchable/Touchable.tsx
@@ -57,7 +57,7 @@ export const Touchable: React.FC<TouchableProps> = ({
     </TouchableWithoutFeedback>
   ) : (
     <TouchableHighlight
-      underlayColor={underlayColor ?? color("transparent")}
+      underlayColor={underlayColor ?? "transparent"}
       activeOpacity={0.8}
       {...props}
       onPress={onPressWrapped}


### PR DESCRIPTION
# Description

This PR resolves [MOPLAT-766](https://artsyproduct.atlassian.net/browse/MOPLAT-766)

Changes `white100` to `transparent` on Touchable `underlayColor` to support dark mode highlight.

### eigen

|Before|After|
|---|---|
|<video src="https://github.com/artsy/palette-mobile/assets/21178754/f5de8087-9454-40db-8c0b-3d2f3a17fb4a" />|<video src="https://github.com/artsy/palette-mobile/assets/21178754/f7fd9ab8-0650-4c69-b284-7bb398e73330" />| 


### energy

#### Dark mode

|Before|After|
|---|---|
|<video src="https://github.com/artsy/palette-mobile/assets/21178754/e4561fc2-ef16-44f2-aa5d-f45e862c5e8b" />|<video src="https://github.com/artsy/palette-mobile/assets/21178754/bcb8c165-985e-4988-830a-dd71d547881e" />|


#### Light mode

|Before|After|
|---|---|
|<video src="https://github.com/artsy/palette-mobile/assets/21178754/7af75915-7323-4077-8c45-77868474b876" />|<video src="https://github.com/artsy/palette-mobile/assets/21178754/65a48f54-6c11-49f6-a4db-97b6eb08d870" />| 










[MOPLAT-766]: https://artsyproduct.atlassian.net/browse/MOPLAT-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ