### PR TITLE
fix: indicator on android is not visible

### DIFF
--- a/src/elements/Tabs/TabsContainer.tsx
+++ b/src/elements/Tabs/TabsContainer.tsx
@@ -1,3 +1,4 @@
+import { Platform } from "react-native"
 import {
   Tabs as BaseTabs,
   MaterialTabBar,
@@ -9,7 +10,6 @@ import { useColor } from "../../utils/hooks/useColor"
 import { useSpace } from "../../utils/hooks/useSpace"
 import { Box } from "../Box"
 import { Flex } from "../Flex"
-import { Text } from "../Text"
 
 const TAB_BAR_HEIGHT = 50
 
@@ -37,6 +37,8 @@ export const TabsContainer: React.FC<TabsContainerProps> = ({
 }) => {
   const space = useSpace()
   const color = useColor()
+
+  const isIOS = Platform.OS === "ios"
 
   return (
     <BaseTabs.Container
@@ -88,7 +90,8 @@ export const TabsContainer: React.FC<TabsContainerProps> = ({
               indicatorStyle={{
                 backgroundColor: color("onBackground"),
                 height: 1,
-                bottom: -1,
+                // on android this line breaks the active indicator and it is not visible
+                ...(isIOS && { bottom: -1 }),
               }}
             />
           </>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

On android the active tab indicator was not displayed at all, added a conditional check to leave it as it was on iOS and make it visible on android.

### Android

|Before|After|
|---|---|
|<img width="382" alt="Screenshot 2023-06-26 at 12 29 36" src="https://github.com/artsy/palette-mobile/assets/21178754/1ed486ff-acf9-42d4-bc65-e329ba6936c5">|<img width="382" alt="Screenshot 2023-06-26 at 12 27 07" src="https://github.com/artsy/palette-mobile/assets/21178754/2d82bee0-d9d6-40e2-89c1-763f895a45c4">|



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
