### PR TITLE
feat(CX-3748): Add private icon to Entity Header

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -36,6 +36,7 @@ const getStories = () => {
     require("../src/elements/Collapse/Collapse.stories.tsx"),
     require("../src/elements/CollapsibleMenuItem/CollapsibleMenuItem.stories.tsx"),
     require("../src/elements/Dialog/Dialog.stories.tsx"),
+    require("../src/elements/EntityHeader/EntityHeader.stories.tsx"),
     require("../src/elements/Image/Image.stories.tsx"),
     require("../src/elements/Input/Input.stories.tsx"),
     require("../src/elements/List/List.stories.tsx"),

--- a/src/elements/EntityHeader/EntityHeader.stories.tsx
+++ b/src/elements/EntityHeader/EntityHeader.stories.tsx
@@ -1,0 +1,124 @@
+import { EntityHeader } from "./EntityHeader"
+import { AvatarSize } from "../Avatar"
+import { Box } from "../Box"
+import { Button } from "../Button"
+import { Text } from "../Text"
+
+export default {
+  title: "EntityHeader",
+  component: EntityHeader,
+}
+
+const avatarSizes: AvatarSize[] = ["xxs", "xs", "sm", "md"]
+
+export const Initials = () => {
+  return (
+    <Box>
+      <Text variant="md">Avatar Sizes</Text>
+
+      <Box mx={2}>
+        {avatarSizes.map((size) => (
+          <Box mb={1}>
+            <Text>{size}</Text>
+            <EntityHeader name="Artist Name" initials="AN" meta="Meta stuff" avatarSize={size} />
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
+export const Image = () => {
+  return (
+    <Box>
+      <Text variant="md">Avatar Sizes</Text>
+
+      <Box mx={2}>
+        {avatarSizes.map((size) => (
+          <Box mb={1}>
+            <Text>{size}</Text>
+            <EntityHeader
+              imageUrl="https://picsum.photos/200/200"
+              name="Artist Name"
+              initials="AN"
+              meta="Meta stuff"
+              avatarSize={size}
+            />
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
+export const VariantSmall = () => {
+  return (
+    <Box>
+      <Text variant="md">Avatar Sizes</Text>
+
+      <Box mx={2}>
+        {avatarSizes.map((size) => (
+          <Box mb={1}>
+            <Text>{size}</Text>
+            <EntityHeader
+              imageUrl="https://picsum.photos/200/200"
+              name="Artist Name"
+              initials="AN"
+              meta="Meta stuff"
+              avatarSize={size}
+              smallVariant
+            />
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
+export const WithRightButton = () => {
+  return (
+    <Box>
+      <Text variant="md">Avatar Sizes</Text>
+
+      <Box mx={2}>
+        {avatarSizes.map((size) => (
+          <Box mb={1}>
+            <Text>{size}</Text>
+            <EntityHeader
+              imageUrl="https://picsum.photos/200/200"
+              name="Artist Name"
+              initials="AN"
+              meta="Meta stuff"
+              avatarSize={size}
+              RightButton={<Button size="small">Right Button</Button>}
+            />
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}
+
+export const WithLockIcon = () => {
+  return (
+    <Box>
+      <Text variant="md">Avatar Sizes</Text>
+
+      <Box mx={2}>
+        {avatarSizes.map((size) => (
+          <Box mb={1}>
+            <Text>{size}</Text>
+            <EntityHeader
+              imageUrl="https://picsum.photos/200/200"
+              name="Artist Name"
+              initials="AN"
+              meta="Meta stuff"
+              avatarSize={size}
+              showLockIcon
+            />
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  )
+}

--- a/src/elements/EntityHeader/EntityHeader.stories.tsx
+++ b/src/elements/EntityHeader/EntityHeader.stories.tsx
@@ -99,7 +99,7 @@ export const WithRightButton = () => {
   )
 }
 
-export const WithLockIcon = () => {
+export const WithPrivateIcon = () => {
   return (
     <Box>
       <Text variant="md">Avatar Sizes</Text>
@@ -114,7 +114,7 @@ export const WithLockIcon = () => {
               initials="AN"
               meta="Meta stuff"
               avatarSize={size}
-              showLockIcon
+              displayPrivateIcon
             />
           </Box>
         ))}

--- a/src/elements/EntityHeader/EntityHeader.tsx
+++ b/src/elements/EntityHeader/EntityHeader.tsx
@@ -44,15 +44,18 @@ export const EntityHeader = ({
   )
 
   const headerName = (
-    <Text ellipsizeMode="tail" numberOfLines={1} variant="sm" style={{ flexShrink: 1 }}>
-      {name}
-      {showLockIcon ? (
-        <>
-          {" "}
-          <LockIcon />
-        </>
-      ) : null}
-    </Text>
+    <Flex flexDirection="row" alignItems="center">
+      <Text
+        ellipsizeMode="tail"
+        numberOfLines={1}
+        variant="sm"
+        lineHeight="18px"
+        style={{ flexShrink: 1 }}
+      >
+        {name}
+      </Text>
+      {showLockIcon && <LockIcon ml="2px" />}
+    </Flex>
   )
 
   const headerMeta = useMemo(() => {

--- a/src/elements/EntityHeader/EntityHeader.tsx
+++ b/src/elements/EntityHeader/EntityHeader.tsx
@@ -1,4 +1,5 @@
 import { isValidElement, useMemo } from "react"
+import { LockIcon } from "../../svgs"
 import { bullet } from "../../utils/text"
 import { Avatar, AvatarSize } from "../Avatar"
 import { Flex, FlexProps } from "../Flex"
@@ -6,7 +7,9 @@ import { Text } from "../Text"
 
 interface EntityHeaderProps extends FlexProps {
   avatarSize?: AvatarSize
-  // @deprecated Use `RightButton` instead
+  /**
+   * @deprecated Use `RightButton` instead
+   */
   FollowButton?: JSX.Element
   RightButton?: JSX.Element
   imageUrl?: string
@@ -14,6 +17,7 @@ interface EntityHeaderProps extends FlexProps {
   meta?: string | JSX.Element
   name: string
   smallVariant?: boolean
+  showLockIcon?: boolean
 }
 
 export const EntityHeader = ({
@@ -25,6 +29,7 @@ export const EntityHeader = ({
   meta,
   name,
   smallVariant = false,
+  showLockIcon,
   ...restProps
 }: EntityHeaderProps) => {
   const rightButton = (RightButton || FollowButton) && (
@@ -41,6 +46,12 @@ export const EntityHeader = ({
   const headerName = (
     <Text ellipsizeMode="tail" numberOfLines={1} variant="sm" style={{ flexShrink: 1 }}>
       {name}
+      {showLockIcon ? (
+        <>
+          {" "}
+          <LockIcon />
+        </>
+      ) : null}
     </Text>
   )
 

--- a/src/elements/EntityHeader/EntityHeader.tsx
+++ b/src/elements/EntityHeader/EntityHeader.tsx
@@ -5,7 +5,7 @@ import { Avatar, AvatarSize } from "../Avatar"
 import { Flex, FlexProps } from "../Flex"
 import { Text } from "../Text"
 
-interface EntityHeaderProps extends FlexProps {
+export interface EntityHeaderProps extends FlexProps {
   avatarSize?: AvatarSize
   /**
    * @deprecated Use `RightButton` instead

--- a/src/elements/EntityHeader/EntityHeader.tsx
+++ b/src/elements/EntityHeader/EntityHeader.tsx
@@ -17,7 +17,7 @@ export interface EntityHeaderProps extends FlexProps {
   meta?: string | JSX.Element
   name: string
   smallVariant?: boolean
-  showLockIcon?: boolean
+  displayPrivateIcon?: boolean
 }
 
 export const EntityHeader = ({
@@ -29,7 +29,7 @@ export const EntityHeader = ({
   meta,
   name,
   smallVariant = false,
-  showLockIcon,
+  displayPrivateIcon,
   ...restProps
 }: EntityHeaderProps) => {
   const rightButton = (RightButton || FollowButton) && (
@@ -54,7 +54,7 @@ export const EntityHeader = ({
       >
         {name}
       </Text>
-      {showLockIcon && <LockIcon ml="2px" />}
+      {displayPrivateIcon && <LockIcon ml="2px" />}
     </Flex>
   )
 


### PR DESCRIPTION
This PR resolves [CX-3748] <!-- eg [PROJECT-XXXX] -->

### Description
This PR adds a private icon to the Entity Header when the prop `displayPrivateIcon` is passed
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### Screenshots

| iOS | Android |
|---|---|
| ![image](https://github.com/artsy/palette-mobile/assets/20655703/72424449-f8da-44d0-a3db-53b39ef11d38) | ![image](https://github.com/artsy/palette-mobile/assets/20655703/d38c8af1-d11e-4951-ba20-f00da9b41024) |


### Follow-up
After merging this, a PR will be opened in [Eigen] to add it to the new Artist Collected feature




[CX-3748]: https://artsyproduct.atlassian.net/browse/CX-3748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[Eigen]: https://github.com/artsy/eigen