### PR TITLE
feat(Image): enable more styling on the Image element and more

### DIFF
--- a/src/elements/Image/Image.stories.tsx
+++ b/src/elements/Image/Image.stories.tsx
@@ -33,15 +33,31 @@ storiesOf("Image", module)
   .add("With percentage width and height", () => {
     return (
       <Flex flexDirection="row" flex={1}>
-        <Flex flex={1} style={{ aspectRatio: 0.62 }}>
+        <Flex flex={1} style={{ aspectRatio: 0.69 }}>
           <Image
             src="https://d32dm0rphc51dk.cloudfront.net/A983VUIZusVBKy420xP3ow/normalized.jpg"
+            height={260}
+            width={180}
             style={{ width: "100%", height: "100%" }}
           />
         </Flex>
 
         <Flex flex={1} style={{ aspectRatio: 1 }}>
-          <Image src="https://i.imgur.com/b9IZinu.gif" style={{ width: "100%", height: "100%" }} />
+          <Image
+            src="https://i.imgur.com/b9IZinu.gif"
+            width={200}
+            height={200}
+            style={{ width: "100%", height: "100%" }}
+          />
+        </Flex>
+
+        <Flex flex={1} style={{ aspectRatio: 1.2 }}>
+          <Image
+            width={200}
+            height={240}
+            src="https://i.imgur.com/non-existing-image.gif"
+            style={{ width: "100%", height: "100%" }}
+          />
         </Flex>
       </Flex>
     )

--- a/src/elements/Image/Image.stories.tsx
+++ b/src/elements/Image/Image.stories.tsx
@@ -1,5 +1,6 @@
 import { storiesOf } from "@storybook/react-native"
 import { Image } from "./Image"
+import { Flex } from "../Flex"
 
 storiesOf("Image", module)
   .add("With default fallback screen width", () => (
@@ -29,3 +30,19 @@ storiesOf("Image", module)
       src="https://d32dm0rphc51dk.cloudfront.net/A983VUIZusVBKy420xP3ow/normalized.jpg"
     />
   ))
+  .add("With percentage width and height", () => {
+    return (
+      <Flex flexDirection="row" flex={1}>
+        <Flex flex={1} style={{ aspectRatio: 0.62 }}>
+          <Image
+            src="https://d32dm0rphc51dk.cloudfront.net/A983VUIZusVBKy420xP3ow/normalized.jpg"
+            style={{ width: "100%", height: "100%" }}
+          />
+        </Flex>
+
+        <Flex flex={1} style={{ aspectRatio: 1 }}>
+          <Image src="https://i.imgur.com/b9IZinu.gif" style={{ width: "100%", height: "100%" }} />
+        </Flex>
+      </Flex>
+    )
+  })

--- a/src/elements/Image/Image.tsx
+++ b/src/elements/Image/Image.tsx
@@ -4,6 +4,7 @@ import { PixelRatio } from "react-native"
 import FastImage, { FastImageProps } from "react-native-fast-image"
 import { Easing } from "react-native-reanimated"
 import { createGeminiUrl } from "../../utils/createGeminiUrl"
+import { useColor } from "../../utils/hooks"
 import { useScreenDimensions } from "../../utils/hooks/useScreenDimensions"
 import { Flex } from "../Flex"
 import { Skeleton, SkeletonBox } from "../Skeleton"
@@ -30,13 +31,15 @@ export const Image: React.FC<ImageProps> = ({
   performResize = true,
   src,
   style,
-  ...imageProps
+  resizeMode,
+  ...flexProps
 }) => {
   const [loading, setLoading] = useState(true)
   const dimensions = useImageDimensions({ aspectRatio, width, height })
+  const color = useColor()
 
   let uri = src
-  if (performResize && dimensions) {
+  if (performResize) {
     uri = createGeminiUrl({
       imageURL: src,
       width: PixelRatio.getPixelSizeForLayoutSize(dimensions.width),
@@ -45,7 +48,7 @@ export const Image: React.FC<ImageProps> = ({
   }
 
   return (
-    <Flex position="relative">
+    <Flex position="relative" {...flexProps}>
       {!!loading && (
         <Flex position="absolute" zIndex={1}>
           <Skeleton>
@@ -59,8 +62,8 @@ export const Image: React.FC<ImageProps> = ({
         transition={{ type: "timing", duration: 400, easing: Easing.sin }}
       >
         <FastImage
-          style={[style, dimensions]}
-          {...imageProps}
+          style={[dimensions, style, { backgroundColor: color("black30") }]}
+          resizeMode={resizeMode}
           onLoadStart={() => setLoading(true)}
           onLoadEnd={() => setLoading(false)}
           source={{
@@ -76,10 +79,6 @@ export const Image: React.FC<ImageProps> = ({
 const useImageDimensions = (props: Pick<ImageProps, "aspectRatio" | "width" | "height">) => {
   const screenDimensions = useScreenDimensions()
 
-  if (!props.aspectRatio && !props.height && !props.width) {
-    return null
-  }
-
   const imageWidth = props.width ?? screenDimensions.width
 
   let imageHeight
@@ -88,7 +87,7 @@ const useImageDimensions = (props: Pick<ImageProps, "aspectRatio" | "width" | "h
     imageHeight = props.height
   } else {
     if (!props.aspectRatio) {
-      console.error("[CachedImage] Error: `aspectRatio` is required if `height` is not provided.")
+      console.error("[Image] Error: `aspectRatio` is required if `height` is not provided.")
     }
 
     const aspectRatio = props.aspectRatio ?? 1

--- a/src/elements/Image/Image.tsx
+++ b/src/elements/Image/Image.tsx
@@ -1,14 +1,16 @@
 import { MotiView } from "moti"
 import { useState } from "react"
 import { PixelRatio } from "react-native"
-import FastImage from "react-native-fast-image"
+import FastImage, { FastImageProps } from "react-native-fast-image"
 import { Easing } from "react-native-reanimated"
 import { createGeminiUrl } from "../../utils/createGeminiUrl"
 import { useScreenDimensions } from "../../utils/hooks/useScreenDimensions"
-import { Flex, FlexProps } from "../Flex"
+import { Flex } from "../Flex"
 import { Skeleton, SkeletonBox } from "../Skeleton"
 
-export interface ImageProps extends FlexProps {
+type CustomFastImageProps = Omit<FastImageProps, "onLoadStart" | "onLoadEnd" | "source">
+
+export interface ImageProps extends CustomFastImageProps {
   /** Supplied aspect ratio of image. If none provided, defaults to 1 */
   aspectRatio?: number
   /** Supplied width of image. If none provided, defaults to screen width */
@@ -27,13 +29,14 @@ export const Image: React.FC<ImageProps> = ({
   height,
   performResize = true,
   src,
-  ...flexProps
+  style,
+  ...imageProps
 }) => {
   const [loading, setLoading] = useState(true)
   const dimensions = useImageDimensions({ aspectRatio, width, height })
 
   let uri = src
-  if (performResize) {
+  if (performResize && dimensions) {
     uri = createGeminiUrl({
       imageURL: src,
       width: PixelRatio.getPixelSizeForLayoutSize(dimensions.width),
@@ -42,7 +45,7 @@ export const Image: React.FC<ImageProps> = ({
   }
 
   return (
-    <Flex position="relative" {...flexProps}>
+    <Flex position="relative">
       {!!loading && (
         <Flex position="absolute" zIndex={1}>
           <Skeleton>
@@ -56,7 +59,8 @@ export const Image: React.FC<ImageProps> = ({
         transition={{ type: "timing", duration: 400, easing: Easing.sin }}
       >
         <FastImage
-          style={dimensions}
+          style={[style, dimensions]}
+          {...imageProps}
           onLoadStart={() => setLoading(true)}
           onLoadEnd={() => setLoading(false)}
           source={{
@@ -71,6 +75,10 @@ export const Image: React.FC<ImageProps> = ({
 
 const useImageDimensions = (props: Pick<ImageProps, "aspectRatio" | "width" | "height">) => {
   const screenDimensions = useScreenDimensions()
+
+  if (!props.aspectRatio && !props.height && !props.width) {
+    return null
+  }
 
   const imageWidth = props.width ?? screenDimensions.width
 


### PR DESCRIPTION
### Description

This PR enables prop drilling into the Image element, respecting FastImage props types. Summary of changes:

- If we pass width and width inside style prop, the prior one has priority over
- enables to use more properties from the native element such as resizeMode

I checked the usage in Eigen and we use only [here](https://github.com/artsy/eigen/blob/a717ab184cb495fbee8212bc4c557d3425bce435/src/app/Scenes/Home/Components/HeroUnitsRail.tsx#L41) and [here](https://github.com/artsy/eigen/blob/a717ab184cb495fbee8212bc4c557d3425bce435/src/app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionImage.tsx#L21), so these changes are not breaking anything, but I haven't checked Folio so far 🤔 

https://github.com/artsy/palette-mobile/assets/15792853/25782721-ecd9-415b-a7f1-3575f9df63de





