### PR TITLE
fix: tab title breaking in smaller phone layouts

### DIFF
--- a/src/elements/Tabs/TabsContainer.tsx
+++ b/src/elements/Tabs/TabsContainer.tsx
@@ -86,7 +86,7 @@ export const TabsContainer: React.FC<TabsContainerProps> = ({
               contentContainerStyle={{}}
               activeColor={color("onBackground")}
               inactiveColor={color("onBackgroundMedium")}
-              labelStyle={{ marginTop: 0 }} // removing the horizonal margin from the lib
+              labelStyle={{ marginHorizontal: 0 }} // removing the horizonal margin from the lib
               indicatorStyle={{
                 backgroundColor: color("onBackground"),
                 height: 1,


### PR DESCRIPTION
This PR resolves [https://www.notion.so/artsy/Auction-Results-tab-title-breaks-to-two-lines-presumably-this-happened-before-as-well-51597973c1844a8a9c77d7f64ca24b14] <!-- eg [PROJECT-XXXX] -->

### Description

https://www.notion.so/artsy/Auction-Results-tab-title-breaks-to-two-lines-presumably-this-happened-before-as-well-51597973c1844a8a9c77d7f64ca24b14

Fixes a launch blocking issue that was making bigger tab titles to break into two lines:

iPhone SE screenshots 

|Before|After|
|---|---|
|<img width="411" alt="Screenshot 2023-07-10 at 11 40 08" src="https://github.com/artsy/palette-mobile/assets/21178754/2f64c107-6df3-428f-a9b7-35b584e4a2a7">|![Screenshot 2023-07-10 at 11 23 36](https://github.com/artsy/palette-mobile/assets/21178754/ffbea9dd-f630-4ff9-aa7c-e69f14254e1c)| 




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
