### PR TITLE
fix: adjust the size of LockIcon

### DIFF
--- a/src/elements/EntityHeader/EntityHeader.tsx
+++ b/src/elements/EntityHeader/EntityHeader.tsx
@@ -54,7 +54,7 @@ export const EntityHeader = ({
       >
         {name}
       </Text>
-      {displayPrivateIcon && <LockIcon ml="2px" />}
+      {displayPrivateIcon && <LockIcon ml="2px" width={16} height={16} testID="lock-icon" />}
     </Flex>
   )
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Adjust the size of `LockIcon` inside `EntityHeader`

Changed the size from 18 to 16
16 is the text size, and 18 is the line height. The icon should be the same size as the text
| before | after |
| --- | --- |
| [screenshots from the previous PR](https://github.com/artsy/palette-mobile/pull/119) | ![simulator_screenshot_D42A4FDF-936D-40E7-8063-D9D671F1702A](https://github.com/artsy/palette-mobile/assets/36167539/34ffcb85-b292-40da-9616-5888fd491aa0) |

