### PR TITLE
fix: reset tab padding style to avoid line breaks

### DIFF
--- a/src/elements/Tabs/TabsContainer.tsx
+++ b/src/elements/Tabs/TabsContainer.tsx
@@ -93,6 +93,11 @@ export const TabsContainer: React.FC<TabsContainerProps> = ({
                 // on android this line breaks the active indicator and it is not visible
                 ...(isIOS && { bottom: -1 }),
               }}
+              tabStyle={{
+                // resets the default padding 10 from the lib
+                // to prevent linebreaks on the tab titles
+                paddingHorizontal: 0,
+              }}
             />
           </>
         )


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Resets paddingHorizontal from [inside the library](https://github.com/PedroBern/react-native-collapsible-tab-view/blob/ea2acf3407674cb5ce301ab34d20347a422396ea/src/MaterialTabBar/TabItem.tsx#L94) to prevent text line breaks in smaller components. 

Checked also the rest of the surfaces and nothing breaks.

Screenshots from eigen:

|Before|After|
|---|---|
|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-07-28 at 12 45 38](https://github.com/artsy/palette-mobile/assets/21178754/95778ec8-8fa9-4cc8-aa60-67cd80a6184f)|![Simulator Screenshot - iPhone SE (3rd generation) - 2023-07-28 at 12 45 29](https://github.com/artsy/palette-mobile/assets/21178754/454848d2-71bc-4d5d-8855-c9b3fc2978c9)|


Needed for https://github.com/artsy/eigen/pull/9057

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
