### PR TITLE
build(REVERT): bumps palette to reanimated 3

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,17 +1,18 @@
-module.exports = {
-  plugins: [
-    "@babel/plugin-transform-flow-strip-types",
-    ["@babel/plugin-proposal-decorators", { version: "legacy" }],
-    ["@babel/plugin-proposal-private-methods", { loose: true }], // needed for latest jest, must come after decorators
-    ["@babel/plugin-proposal-class-properties", { loose: true }], // must come after decorators
-    "react-native-reanimated/plugin", // should be LAST
+const plugins = [
+  "@babel/plugin-transform-flow-strip-types",
+  ["@babel/plugin-proposal-decorators", { version: "legacy" }],
+  ["@babel/plugin-proposal-private-methods", { loose: true }], // needed for latest jest, must come after decorators
+  ["@babel/plugin-proposal-class-properties", { loose: true }], // must come after decorators
+  "react-native-reanimated/plugin", // should be LAST
+]
+
+const presets = [
+  [
+    "module:metro-react-native-babel-preset",
+    { useTransformReactJSXExperimental: true }, // this is so `import React from "react"` is not needed.
   ],
-  presets: [
-    [
-      "module:metro-react-native-babel-preset",
-      { useTransformReactJSXExperimental: true }, // this is so `import React from "react"` is not needed.
-    ],
-    "@babel/preset-typescript",
-    ["@babel/preset-react", { runtime: "automatic" }], // this is so `import React from "react"` is not needed.
-  ],
-}
+  "@babel/preset-typescript",
+  ["@babel/preset-react", { runtime: "automatic" }], // this is so `import React from "react"` is not needed.
+]
+
+module.exports = {  plugins,presets }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -399,12 +399,11 @@ PODS:
     - SDWebImageWebPCoder (~> 0.8.4)
   - RNReactNativeHapticFeedback (1.14.0):
     - React-Core
-  - RNReanimated (3.3.0):
+  - RNReanimated (2.14.4):
     - DoubleConversion
     - FBLazyVector
     - FBReactNativeSpec
     - glog
-    - hermes-engine
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -414,7 +413,6 @@ PODS:
     - React-Core/RCTWebSocket
     - React-CoreModules
     - React-cxxreact
-    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
@@ -640,7 +638,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: cbdee19bdd4e7f05472a66ce290f1b729ba3cb86
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 3d02b25ca00c2d456734d0bcff864cbc62f6ae1a
   hermes-engine: 0b19f33a9c2ec1dbdede3232606eeb1101db4cec
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
@@ -679,7 +677,7 @@ SPEC CHECKSUMS:
   RNDeviceInfo: 4701f0bf2a06b34654745053db0ce4cb0c53ada7
   RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
   RNReactNativeHapticFeedback: 1e3efeca9628ff9876ee7cdd9edec1b336913f8c
-  RNReanimated: 38e8c4a0232f4596ba46b547ae8b9a8192322dea
+  RNReanimated: 6668b0587bebd4b15dd849b99e5a9c70fc12ed95
   RNSVG: d787d64ca06b9158e763ad2638a8c4edce00782a
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "react-native-flipper": "0.178.1",
     "react-native-haptic-feedback": "1.14.0",
     "react-native-linear-gradient": "2.6.2",
-    "react-native-reanimated": "^3.3.0",
+    "react-native-reanimated": "2.14.4",
     "react-native-safe-area-context": "4.5.0",
     "react-native-svg": "13.7.0",
     "react-test-renderer": "18.2.0",

--- a/src/elements/ButtonNew/Button.tsx
+++ b/src/elements/ButtonNew/Button.tsx
@@ -134,6 +134,7 @@ export const Button = ({
   const colorsForVariantAndState = useColorsForVariantAndState()
 
   const containerColorsAnim = useAnimatedStyle(() => {
+    "worklet"
     const colors = colorsForVariantAndState[variant]
     if (disabled) {
       return {
@@ -156,6 +157,7 @@ export const Button = ({
   })
 
   const textAnim = useAnimatedStyle(() => {
+    "worklet"
     const colors = colorsForVariantAndState[variant]
     if (loading) {
       return { color: "rgba(0, 0, 0, 0)" }
@@ -274,6 +276,8 @@ const useStateWithProp = (
     setState(!!prop)
   }, [prop])
   const stateV = useDerivedValue(() => {
+    "worklet"
+
     if (!!state) {
       return 1
     }

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -47,6 +47,8 @@ export const Pill: React.FC<PillProps> = ({
         animate={useMemo(
           () =>
             ({ hovered, pressed }) => {
+              "worklet"
+
               return {
                 opacity: hovered || pressed ? 0.5 : 1,
               }

--- a/src/elements/ProgressBar/ProgressBar.tsx
+++ b/src/elements/ProgressBar/ProgressBar.tsx
@@ -27,6 +27,7 @@ export const ProgressBar = ({
   const width = useSharedValue("0%")
   const progress = clamp(unclampedProgress, 0, 100)
   const progressAnim = useAnimatedStyle(() => {
+    "worklet"
     return { width: width.value }
   })
 

--- a/src/elements/Screen/ScreenFlatList.tsx
+++ b/src/elements/Screen/ScreenFlatList.tsx
@@ -14,5 +14,5 @@ export function ScreenFlatList<T>(props: FlatListProps<T>) {
     handleScroll = scrollHandler
   }
 
-  return <Animated.FlatList {...props} onScroll={handleScroll} />
+  return <Animated.FlatList<T> {...props} onScroll={handleScroll} />
 }

--- a/src/elements/Screen/hooks/useAnimatedHeaderScrolling.tsx
+++ b/src/elements/Screen/hooks/useAnimatedHeaderScrolling.tsx
@@ -23,9 +23,13 @@ export const useAnimatedHeaderScrolling = (scrollY: SharedValue<number>) => {
 
   useAnimatedReaction(
     () => {
+      "worklet"
+
       return [scrollY.value, listenForScroll.value] as const
     },
     ([animatedScrollY, isListeningForScroll], previousScroll) => {
+      "worklet"
+
       const [prevScrollY] = previousScroll ?? [0, false]
 
       // Hacky way to avoid some weird header behavior.

--- a/src/elements/Screen/hooks/useListenForScreenScroll.tsx
+++ b/src/elements/Screen/hooks/useListenForScreenScroll.tsx
@@ -10,6 +10,7 @@ export const useListenForScreenScroll = () => {
 
   const scrollHandler = useAnimatedScrollHandler({
     onScroll: (event) => {
+      "worklet"
       animatedScrollY.value = event.contentOffset.y
     },
   })

--- a/src/elements/Skeleton/Skeleton.tsx
+++ b/src/elements/Skeleton/Skeleton.tsx
@@ -24,6 +24,7 @@ export const Skeleton: FC<{ children: ReactNode }> = ({ children }) => {
   const opacity = useSharedValue(0.5)
   opacity.value = withRepeat(withTiming(1, { duration: 1000, easing: Easing.ease }), -1, true)
   const fadeLoopAnim = useAnimatedStyle(() => {
+    "worklet"
     return { opacity: opacity.value }
   }, [])
 

--- a/src/elements/Tabs/SubTabBar.tsx
+++ b/src/elements/Tabs/SubTabBar.tsx
@@ -15,6 +15,8 @@ export const SubTabBar: React.FC<React.PropsWithChildren> = ({ children }) => {
   const space = useSpace()
 
   const style = useAnimatedStyle(() => {
+    "worklet"
+
     return {
       transform: [
         {

--- a/src/elements/ToolTip/ToolTipFlyout.tsx
+++ b/src/elements/ToolTip/ToolTipFlyout.tsx
@@ -31,6 +31,7 @@ export const ToolTipFlyout: React.FC<Props> = ({
   const boxDimensions = useSharedValue(initialBoxDimensions)
 
   const animationStyle = useAnimatedStyle(() => {
+    "worklet"
     return {
       height: withTiming(boxDimensions.value.height, {
         duration: 500,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7886,6 +7886,11 @@ lodash.get@^4:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -9403,15 +9408,18 @@ react-native-pager-view@^6.2.0:
   resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.2.0.tgz#51380d93fbe47f6380dc71d613a787bf27a4ca37"
   integrity sha512-pf9OnL/Tkr+5s4Gjmsn7xh91PtJLDa6qxYa/bmtUhd/+s4cQdWQ8DIFoOFghwZIHHHwVdWtoXkp6HtpjN+r20g==
 
-react-native-reanimated@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.3.0.tgz#80f9d58e28fddf62fe4c1bc792337b8ab57936ab"
-  integrity sha512-LzfpPZ1qXBGy5BcUHqw3pBC0qSd22qXS3t8hWSbozXNrBkzMhhOrcILE/nEg/PHpNNp1xvGOW8NwpAMF006roQ==
+react-native-reanimated@2.14.4:
+  version "2.14.4"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-2.14.4.tgz#3fa3da4e7b99f5dfb28f86bcf24d9d1024d38836"
+  integrity sha512-DquSbl7P8j4SAmc+kRdd75Ianm8G+IYQ9T4AQ6lrpLVeDkhZmjWI0wkutKWnp6L7c5XNVUrFDUf69dwETLCItQ==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"
-    convert-source-map "^2.0.0"
+    convert-source-map "^1.7.0"
     invariant "^2.2.4"
+    lodash.isequal "^4.5.0"
+    setimmediate "^1.0.5"
+    string-hash-64 "^1.0.3"
 
 react-native-safe-area-context@4.5.0:
   version "4.5.0"
@@ -9985,6 +9993,11 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
+
 setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
@@ -10266,6 +10279,11 @@ string-argv@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
+
+string-hash-64@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string-hash-64/-/string-hash-64-1.0.3.tgz#0deb56df58678640db5c479ccbbb597aaa0de322"
+  integrity sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==
 
 string-length@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Reverts artsy/palette-mobile#125

## Description

will revert the reanimated palette version bump and will go with a canary version till I resolve the issues on the eigen reanimated PR.
So far the only issue seems to be another extremely deprecated package react-native-credit-card-input that was patched from david to use reanimated 1 code.
There is a video there for the behavior of the why this was patched so will go ahead and fix it on Tuesday and then proceed with a palette-mobile release with reanimated 3

