### PR TITLE
feat: add Tabs.Masonry and bump react-native-collapsible-tab-view from 6.1.4 to 6.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.17.21",
     "moti": "^0.25.3",
     "react-nanny": "^2.15.0",
-    "react-native-collapsible-tab-view": "^6.1.4",
+    "react-native-collapsible-tab-view": "^6.2.0",
     "react-native-fast-image": "^8.6.3",
     "react-native-pager-view": "^6.2.0",
     "react-spring": "8.0.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9361,10 +9361,10 @@ react-native-codegen@^0.70.6:
     jscodeshift "^0.13.1"
     nullthrows "^1.1.1"
 
-react-native-collapsible-tab-view@^6.1.4:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/react-native-collapsible-tab-view/-/react-native-collapsible-tab-view-6.1.4.tgz#011c8abab29d9229a22caa287395f0081fae644e"
-  integrity sha512-eGGAdze91WgXOrd+8wPsd18YxdrQvp8WlR4bv7GjgGwkzM72Ka7esz3GhHeDb6F6MxDYAvwfgm2Q4kDLvxaRTw==
+react-native-collapsible-tab-view@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-collapsible-tab-view/-/react-native-collapsible-tab-view-6.2.0.tgz#f57409f40e4f5a1a9eefdc7d32cad0fd61d2ef56"
+  integrity sha512-EAlsatGZpoqr2SBRU0iAO6mUENoXB8yXhjqVD/e/S+9yNlWyJBR5JxqIWhtbqOt/WAqpwb18ipDECusRoDkbiA==
   dependencies:
     use-deep-compare "^1.1.0"
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Bumps react-native-collapsible-tab-view from 6.1.4 to 6.2.0 in order to be able to start playing around with the Tabs.Masonry in the artwork grids across eigen now that the [MasonryFlashList PR](https://github.com/PedroBern/react-native-collapsible-tab-view/pull/353) got merged and released!

#### Follow ups:

- [ ] install shopify/flashlist ? or can we install it only in eigen?
- [ ] open a PR to export Tabs.Masonry from palette

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
