### PR TITLE
fix(Pill): remove animation from MotiPressable

### DIFF
--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -1,7 +1,6 @@
 import { Color } from "@artsy/palette-tokens"
 import themeGet from "@styled-system/theme-get"
 import { MotiPressable, MotiPressableProps } from "moti/interactions"
-import { useMemo } from "react"
 import styled, { FlattenInterpolation, css } from "styled-components"
 import { CloseIcon } from "../../svgs"
 import { IconProps } from "../../svgs/Icon"
@@ -39,21 +38,7 @@ export const Pill: React.FC<PillProps> = ({
 
   return (
     <Flex {...rest}>
-      <Container
-        variant={variant}
-        selected={selected}
-        disabled={disabled}
-        onPress={onPress}
-        animate={useMemo(
-          () =>
-            ({ hovered, pressed }) => {
-              return {
-                opacity: hovered || pressed ? 0.5 : 1,
-              }
-            },
-          []
-        )}
-      >
+      <Container variant={variant} selected={selected} disabled={disabled} onPress={onPress}>
         {variant === "artist" && (
           <Thumbnail src={src!} height={30} width={30} style={{ overflow: "hidden" }} />
         )}


### PR DESCRIPTION
### Description

MotiPressable was causing an error after the reanimated bump in Eigen.
This PR removes temporarily the animate prop while we investigate it.

more [info](https://artsy.slack.com/archives/C02BAQ5K7/p1690968005585269)
