### PR TITLE
chore(palette-tokens): bump palette-tokens to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "FOR DEPS NEEDED FOR THE STORYBOOK APP, ADD THEM AS DEV DEPS BELOW."
   ],
   "dependencies": {
-    "@artsy/palette-tokens": "^4.0.1",
+    "@artsy/palette-tokens": "^5.0.0",
     "@styled-system/core": "^5.1.2",
     "@styled-system/theme-get": "^5.1.2",
     "events": "^3.3.0",

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -4,17 +4,17 @@
  * https://www.figma.com/file/gZNkyqLT8AU3T61tluVJyB/Artsy-3.1-Design-System
  */
 
-import { THEME_V3 } from "@artsy/palette-tokens"
+import { THEME } from "@artsy/palette-tokens"
 import { SpacingUnit as SpacingUnitNumbers } from "@artsy/palette-tokens/dist/themes/v3"
 import { TextVariant } from "@artsy/palette-tokens/dist/typography/v3"
-import { Color, ColorDSValue, ColorLayerName, ColorLayerRole, SpacingUnit } from "./types"
+import { Color, ColorDSValue, ColorLayerName, SpacingUnit } from "./types"
 import {
   convertWebSpacingUnitsToMobile,
   convertWebTextTreatmentsToMobile,
   TextTreatmentWithoutUnits,
 } from "./utils/webTokensToMobile"
 
-const { textVariants, space, colors, fonts } = THEME_V3
+const { textVariants, space, colors } = THEME
 
 export interface ThemeType {
   space: Record<SpacingUnitNumbers, `${number}px`>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { SpacingUnit as BaseSpacingUnit } from "@artsy/palette-tokens/dist/themes/v3"
+import { SpacingUnit as BaseSpacingUnit } from "@artsy/palette-tokens"
 import { COLOR_LAYER_ROLE, COLOR_LAYER_NAME } from "./tokens"
 import { Neg } from "./utils/types"
 

--- a/src/utils/hooks/useTheme.tsx
+++ b/src/utils/hooks/useTheme.tsx
@@ -1,6 +1,6 @@
 import { SpacingUnit } from "@artsy/palette-tokens/dist/themes/v3"
 import { useContext } from "react"
-import { DefaultTheme, ThemeContext } from "styled-components/native"
+import { ThemeContext } from "styled-components/native"
 import { AllThemesType, THEMES, ThemeType, ThemeWithDarkModeType } from "../../tokens"
 import { Color, ColorDSValue } from "../../types"
 
@@ -45,8 +45,8 @@ const space =
 // TODO: make this stricter for types. only allow ColorStrict.
 export interface ColorFn {
   (colorNumber: undefined): undefined
-  (colorNumber: ColorDSValue): string
-  (colorNumber: Color | undefined): string | undefined
+  (colorNumber: ColorDSValue | Color): string
+  (colorNumber: ColorDSValue | Color | undefined): string | undefined
 }
 
 const color =

--- a/src/utils/webTokensToMobile.ts
+++ b/src/utils/webTokensToMobile.ts
@@ -1,4 +1,4 @@
-import { THEME_V3 } from "@artsy/palette-tokens"
+import { THEME } from "@artsy/palette-tokens"
 import { SpacingUnit } from "@artsy/palette-tokens/dist/themes/v3"
 import { TextTreatment, TextVariant } from "@artsy/palette-tokens/dist/typography/v3"
 import { mapValues } from "lodash"
@@ -16,7 +16,7 @@ export type TextTreatmentWithoutUnits = {
  * `0.5` to a string `"0.5"`.
  */
 export const convertWebSpacingUnitsToMobile = (
-  withUnits: typeof THEME_V3.space
+  withUnits: typeof THEME.space
 ): Record<SpacingUnit, SpacingUnitPixelValue> => {
   return withUnits as Record<SpacingUnit, SpacingUnitPixelValue>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/auto-config/-/auto-config-1.2.0.tgz#62a237ca3a058f1b91e5b8a12abebae0ddc5bd2f"
   integrity sha512-6zGlvqELl4XhqMajJxfgHaY3m5YhZK5FwkxlouJKSb0Su301bzXaPUxKjzj9X147YHJUyrRLSAruzVtj1Gr42Q==
 
-"@artsy/palette-tokens@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@artsy/palette-tokens/-/palette-tokens-4.0.1.tgz#ef171c0449f3c0a1c0765253a06beec160b0eed1"
-  integrity sha512-JQ4t6eCAL3LpYnwyIMJCKc3UiVWY17IvKadNXRXfplo+GFZUqZs61nFGlchNWZvtNESpHkGKOksA5dZq3G1wiw==
+"@artsy/palette-tokens@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette-tokens/-/palette-tokens-5.0.0.tgz#d1e1917d8163d88e7a9f877cf06b609fa8c8178c"
+  integrity sha512-nloC0ubH5XDVNiplehwTtDLEgY0vjeE3l8QUYppEIHFCgadntXm6aVlmEC79inO7L3lDYN7JckYlIYRrTJg3vw==
 
 "@auto-it/all-contributors@10.38.5":
   version "10.38.5"


### PR DESCRIPTION
### Description

This PR bumps `@artsy/palette-tokens` to the latest version and has some unused vars cleanup too(very small stuff).

Tested locally with Eigen and only 1 component is failing there, once the Palette PR is in Place I'll create another PR in Eigen to fix the typings(`MoneyInput.tsx`).
