### PR TITLE
feat: Add onPress to ToolTip

### DIFF
--- a/src/elements/ToolTip/ToolTip.tsx
+++ b/src/elements/ToolTip/ToolTip.tsx
@@ -16,6 +16,7 @@ interface ToolTipProps {
   enabled?: Boolean
   initialToolTipText?: string
   maxWidth?: number
+  onPress?: () => void
   position?: "TOP" | "BOTTOM"
   tapToDismiss?: boolean
   testID?: string
@@ -55,6 +56,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
   enabled = true,
   initialToolTipText,
   maxWidth,
+  onPress,
   position = "TOP",
   tapToDismiss = false,
   testID,
@@ -109,6 +111,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
             height={finalToolTipHeight}
             width={finalToolTipWidth}
             onClose={dismissToolTip}
+            onToolTipPress={onPress}
             position={position}
             testID={testID}
             text={toolTipText}
@@ -159,6 +162,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
             height={finalToolTipHeight}
             width={finalToolTipWidth}
             onClose={dismissToolTip}
+            onToolTipPress={onPress}
             position={position}
             testID={testID}
             text={toolTipText}


### PR DESCRIPTION
This PR resolves [ONYX-60] <!-- eg [PROJECT-XXXX] -->

### Description

Add `onPress` prop to `ToolTip` to be able to run code when the user presses/dismisses the tooltip.


[ONYX-60]: https://artsyproduct.atlassian.net/browse/ONYX-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ