### PR TITLE
feat(Tabs): add pointerEvents none to tabsWithHeader title

### DIFF
--- a/src/elements/Tabs/Tabs.stories.tsx
+++ b/src/elements/Tabs/Tabs.stories.tsx
@@ -1,6 +1,8 @@
 import { storiesOf } from "@storybook/react-native"
 import { Tabs } from "./Tabs"
+import { Flex } from "../Flex"
 import { Screen } from "../Screen"
+import { Spacer } from "../Spacer"
 import { Text } from "../Text"
 
 storiesOf("Tabs", module)
@@ -69,4 +71,24 @@ storiesOf("Tabs", module)
         </Tabs>
       </Screen.Body>
     </Screen>
+  ))
+  .add("Tabs with header", () => (
+    <Tabs.TabsWithHeader
+      title="My header"
+      BelowTitleHeaderComponent={() => (
+        <Flex pointerEvents="none" p={2}>
+          <Text>Title</Text>
+          <Text>Description</Text>
+        </Flex>
+      )}
+    >
+      <Tabs.Tab name="tab1" label="Tab 1">
+        <Tabs.ScrollView>
+          <Text>{"Some long text ".repeat(150)}</Text>
+        </Tabs.ScrollView>
+      </Tabs.Tab>
+      <Tabs.Tab name="tab2" label="Tab 2">
+        <Text>{"Some long text ".repeat(150)}</Text>
+      </Tabs.Tab>
+    </Tabs.TabsWithHeader>
   ))

--- a/src/elements/Tabs/TabsWithHeader.tsx
+++ b/src/elements/Tabs/TabsWithHeader.tsx
@@ -35,7 +35,7 @@ export const TabsWithHeader: React.FC<TabsWithHeaderProps> = ({
 
             return (
               <>
-                <Flex my={1} pl={2} justifyContent="center" alignSelf="flex-start">
+                <Flex my={1} pl={2} justifyContent="center" pointerEvents="none">
                   <Text variant="lg-display" numberOfLines={2}>
                     {title}
                   </Text>


### PR DESCRIPTION
### Description

Since the title section is just some Views and Text without any interaction we should use pointerEvents `none` in order to have a better UX making the vertical scroll work with the entire content as we see in the video.

https://github.com/artsy/palette-mobile/assets/15792853/10b854b9-dafc-4734-a98a-b509b03282ae

