### PR TITLE
feat(TabsWithHeader): show BelowTitleHeaderComponent if we don't display the title

### DIFF
--- a/src/elements/Tabs/Tabs.stories.tsx
+++ b/src/elements/Tabs/Tabs.stories.tsx
@@ -74,10 +74,11 @@ storiesOf("Tabs", module)
   ))
   .add("Tabs with header", () => (
     <Tabs.TabsWithHeader
-      title="My header"
+      title="Artist Header"
+      showLargeHeaderText={false}
       BelowTitleHeaderComponent={() => (
         <Flex pointerEvents="none" p={2}>
-          <Text>Title</Text>
+          <Text>Artist</Text>
           <Text>Description</Text>
         </Flex>
       )}

--- a/src/elements/Tabs/TabsWithHeader.tsx
+++ b/src/elements/Tabs/TabsWithHeader.tsx
@@ -21,6 +21,8 @@ export const TabsWithHeader: React.FC<TabsWithHeaderProps> = ({
   title,
   ...rest
 }) => {
+  const showTitle = showLargeHeaderText && !!title
+
   return (
     <Screen>
       <Screen.AnimatedHeader title={title} {...headerProps} />
@@ -29,17 +31,15 @@ export const TabsWithHeader: React.FC<TabsWithHeaderProps> = ({
         <TabsContainer
           {...rest}
           renderHeader={() => {
-            if (!showLargeHeaderText || !title) {
-              return null
-            }
-
             return (
               <>
-                <Flex my={1} pl={2} justifyContent="center" pointerEvents="none">
-                  <Text variant="lg-display" numberOfLines={2}>
-                    {title}
-                  </Text>
-                </Flex>
+                {!!showTitle && (
+                  <Flex my={1} pl={2} justifyContent="center" pointerEvents="none">
+                    <Text variant="lg-display" numberOfLines={2}>
+                      {title}
+                    </Text>
+                  </Flex>
+                )}
                 {!!BelowTitleHeaderComponent && <BelowTitleHeaderComponent />}
               </>
             )


### PR DESCRIPTION
### Description

The check to not display the title was also affecting `BelowTitleHeaderComponent`, if we don't want to display the large `title` but still want to display `BelowTitleHeaderComponent` we couldn't with the current logic.

The changes here allow us to use `showLargeHeaderText={false}` and still render the `BelowTitleHeaderComponent` if we want.

PS: I checked Eigen and it looks like we never used `showLargeHeaderText={false}` before.

https://github.com/artsy/palette-mobile/assets/15792853/b5d8feb0-0b4a-4dda-8db4-2bedd88a6229

