### PR TITLE
chore: add build status on circle ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Palette Mobile
 
-# @artsy/palette-mobile [![npm version](https://badge.fury.io/js/%40artsy%2Fpalette-mobile.svg)](https://www.npmjs.com/package/@artsy/palette-mobile) [![Release](https://github.com/artsy/palette-mobile/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/artsy/palette-mobile/actions/workflows/release.yml)
+# @artsy/palette-mobile [![npm version](https://badge.fury.io/js/%40artsy%2Fpalette-mobile.svg)](https://www.npmjs.com/package/@artsy/palette-mobile) [![Release](https://github.com/artsy/palette-mobile/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/artsy/palette-mobile/actions/workflows/release.yml)[![CircleCI](https://dl.circleci.com/status-badge/img/gh/artsy/palette-mobile/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/artsy/palette-mobile/tree/main)
 
 Artsy's Design System on Mobile
 


### PR DESCRIPTION
### Description

This PR adds Circle CI status on main. This is useful to quickly access circle ci and check the build status.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
