### PR TITLE
feat(tabs): adds scroll offsets to the tabs when checking scroll position

### DIFF
--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -26,15 +26,10 @@ export interface HeaderProps {
 }
 
 export const AnimatedHeader: React.FC<HeaderProps> = (props) => {
-  const { currentScrollY, scrollYDetectionOffset } = useScreenScrollContext()
+  const { currentScrollY, scrollYOffset } = useScreenScrollContext()
 
   return (
-    <Header
-      scrollY={currentScrollY}
-      scrollYOffset={scrollYDetectionOffset}
-      animated={true}
-      {...props}
-    />
+    <Header scrollY={currentScrollY} scrollYOffset={scrollYOffset} animated={true} {...props} />
   )
 }
 

--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -18,15 +18,24 @@ export interface HeaderProps {
   onBack?: () => void
   rightElements?: React.ReactNode
   scrollY?: number
+  // For header with more content use the offset to achieve a more granular control when to show the animated header
+  scrollYOffset?: number
   title?: string
   titleProps?: FlexProps
   titleShown?: boolean
 }
 
 export const AnimatedHeader: React.FC<HeaderProps> = (props) => {
-  const { currentScrollY } = useScreenScrollContext()
+  const { currentScrollY, scrollYDetectionOffset } = useScreenScrollContext()
 
-  return <Header scrollY={currentScrollY} animated={true} {...props} />
+  return (
+    <Header
+      scrollY={currentScrollY}
+      scrollYOffset={scrollYDetectionOffset}
+      animated={true}
+      {...props}
+    />
+  )
 }
 
 export const Header: React.FC<HeaderProps> = ({
@@ -38,6 +47,7 @@ export const Header: React.FC<HeaderProps> = ({
   onBack,
   rightElements,
   scrollY = 0,
+  scrollYOffset = 0,
   title,
   titleProps = {},
 }) => {
@@ -80,7 +90,7 @@ export const Header: React.FC<HeaderProps> = ({
     }
 
     // Show / hide the title to avoid rerenders, which retrigger the animation
-    const display = scrollY < NAVBAR_HEIGHT ? "none" : "flex"
+    const display = scrollY < NAVBAR_HEIGHT + scrollYOffset ? "none" : "flex"
 
     return (
       <Flex flex={1} flexDirection="row">

--- a/src/elements/Screen/ScreenScrollContext.tsx
+++ b/src/elements/Screen/ScreenScrollContext.tsx
@@ -3,20 +3,31 @@ import { useContext, createContext, useState } from "react"
 export interface ScreenScrollContextProps {
   currentScrollY: number
   updateCurrentScrollY: (scrollY: number) => void
+  // used by the hooks when measuring the scroll position in a more granular way
+  scrollYDetectionOffset?: number
+  updateScrollYDetectionOffset: (offset: number) => void
 }
 
 const ScreenScrollContext = createContext<ScreenScrollContextProps>({
   currentScrollY: 0,
   updateCurrentScrollY: () => {},
+  scrollYDetectionOffset: undefined,
+  updateScrollYDetectionOffset: () => {},
 })
 
 export const ScreenScrollContextProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [currentScrollY, setCurrentScrollY] = useState(0)
+  const [scrollYDetectionOffset, setScrollYDetectionOffset] =
+    useState<ScreenScrollContextProps["scrollYDetectionOffset"]>(undefined)
 
   const providerValue = {
     currentScrollY,
+    scrollYDetectionOffset,
     updateCurrentScrollY: (scrollY: number) => {
       setCurrentScrollY(scrollY)
+    },
+    updateScrollYDetectionOffset: (scrollYDetectionOffset: number) => {
+      setScrollYDetectionOffset(scrollYDetectionOffset)
     },
   }
 

--- a/src/elements/Screen/ScreenScrollContext.tsx
+++ b/src/elements/Screen/ScreenScrollContext.tsx
@@ -4,30 +4,30 @@ export interface ScreenScrollContextProps {
   currentScrollY: number
   updateCurrentScrollY: (scrollY: number) => void
   // used by the hooks when measuring the scroll position in a more granular way
-  scrollYDetectionOffset?: number
-  updateScrollYDetectionOffset: (offset: number) => void
+  scrollYOffset?: number
+  updateScrollYOffset: (offset: number) => void
 }
 
 const ScreenScrollContext = createContext<ScreenScrollContextProps>({
   currentScrollY: 0,
   updateCurrentScrollY: () => {},
-  scrollYDetectionOffset: undefined,
-  updateScrollYDetectionOffset: () => {},
+  scrollYOffset: undefined,
+  updateScrollYOffset: () => {},
 })
 
 export const ScreenScrollContextProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
   const [currentScrollY, setCurrentScrollY] = useState(0)
-  const [scrollYDetectionOffset, setScrollYDetectionOffset] =
-    useState<ScreenScrollContextProps["scrollYDetectionOffset"]>(undefined)
+  const [scrollYOffset, setScrollYOffset] =
+    useState<ScreenScrollContextProps["scrollYOffset"]>(undefined)
 
   const providerValue = {
     currentScrollY,
-    scrollYDetectionOffset,
+    scrollYOffset,
     updateCurrentScrollY: (scrollY: number) => {
       setCurrentScrollY(scrollY)
     },
-    updateScrollYDetectionOffset: (scrollYDetectionOffset: number) => {
-      setScrollYDetectionOffset(scrollYDetectionOffset)
+    updateScrollYOffset: (yOffset: number) => {
+      setScrollYOffset(yOffset)
     },
   }
 

--- a/src/elements/Screen/hooks/useAnimatedHeaderScrolling.tsx
+++ b/src/elements/Screen/hooks/useAnimatedHeaderScrolling.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { runOnJS, SharedValue, useAnimatedReaction, useSharedValue } from "react-native-reanimated"
 import { NAVBAR_HEIGHT } from "../constants"
 
-export const useAnimatedHeaderScrolling = (scrollY: SharedValue<number>) => {
+export const useAnimatedHeaderScrolling = (scrollY: SharedValue<number>, scrollYOffset = 0) => {
   const listenForScroll = useSharedValue(true)
   const [currScrollY, setCurrScrollY] = useState(scrollY.value)
+  const HEADER_HEIGHT = useMemo(() => NAVBAR_HEIGHT + scrollYOffset, [scrollYOffset])
 
   // Needed to run on JS thread
   const update = (y: number) => {
@@ -30,14 +31,14 @@ export const useAnimatedHeaderScrolling = (scrollY: SharedValue<number>) => {
 
       // Hacky way to avoid some weird header behavior.
       // look at HACKS.md for more info.
-      const suddenlyScrolled = Math.abs(animatedScrollY - prevScrollY) > NAVBAR_HEIGHT
+      const suddenlyScrolled = Math.abs(animatedScrollY - prevScrollY) > HEADER_HEIGHT
 
       if (isListeningForScroll && suddenlyScrolled) {
         return
       }
 
-      const prevTitleShown = prevScrollY >= NAVBAR_HEIGHT
-      const currTitleShown = animatedScrollY >= NAVBAR_HEIGHT
+      const prevTitleShown = prevScrollY >= HEADER_HEIGHT
+      const currTitleShown = animatedScrollY >= HEADER_HEIGHT
 
       if (prevTitleShown === currTitleShown) {
         return
@@ -45,7 +46,7 @@ export const useAnimatedHeaderScrolling = (scrollY: SharedValue<number>) => {
 
       runOnJS(update)(Math.floor(animatedScrollY))
     },
-    [scrollY]
+    [scrollY, HEADER_HEIGHT]
   )
 
   return currScrollY

--- a/src/elements/Screen/hooks/useListenForScreenScroll.tsx
+++ b/src/elements/Screen/hooks/useListenForScreenScroll.tsx
@@ -4,9 +4,9 @@ import { useAnimatedHeaderScrolling } from "./useAnimatedHeaderScrolling"
 import { useScreenScrollContext } from "../ScreenScrollContext"
 
 export const useListenForScreenScroll = () => {
-  const { updateCurrentScrollY, scrollYDetectionOffset } = useScreenScrollContext()
+  const { updateCurrentScrollY, scrollYOffset } = useScreenScrollContext()
   const animatedScrollY = useSharedValue(0)
-  const scrollY = useAnimatedHeaderScrolling(animatedScrollY, scrollYDetectionOffset)
+  const scrollY = useAnimatedHeaderScrolling(animatedScrollY, scrollYOffset)
 
   const scrollHandler = useAnimatedScrollHandler({
     onScroll: (event) => {

--- a/src/elements/Screen/hooks/useListenForScreenScroll.tsx
+++ b/src/elements/Screen/hooks/useListenForScreenScroll.tsx
@@ -4,9 +4,9 @@ import { useAnimatedHeaderScrolling } from "./useAnimatedHeaderScrolling"
 import { useScreenScrollContext } from "../ScreenScrollContext"
 
 export const useListenForScreenScroll = () => {
-  const { updateCurrentScrollY } = useScreenScrollContext()
+  const { updateCurrentScrollY, scrollYDetectionOffset } = useScreenScrollContext()
   const animatedScrollY = useSharedValue(0)
-  const scrollY = useAnimatedHeaderScrolling(animatedScrollY)
+  const scrollY = useAnimatedHeaderScrolling(animatedScrollY, scrollYDetectionOffset)
 
   const scrollHandler = useAnimatedScrollHandler({
     onScroll: (event) => {

--- a/src/elements/Tabs/hooks/useListenForTabContentScroll.tsx
+++ b/src/elements/Tabs/hooks/useListenForTabContentScroll.tsx
@@ -4,8 +4,8 @@ import { useScreenScrollContext } from "../../Screen/ScreenScrollContext"
 import { useAnimatedHeaderScrolling } from "../../Screen/hooks/useAnimatedHeaderScrolling"
 
 export const useListenForTabContentScroll = () => {
-  const { updateCurrentScrollY, scrollYDetectionOffset } = useScreenScrollContext()
-  const scrollY = useAnimatedHeaderScrolling(useCurrentTabScrollY(), scrollYDetectionOffset)
+  const { updateCurrentScrollY, scrollYOffset } = useScreenScrollContext()
+  const scrollY = useAnimatedHeaderScrolling(useCurrentTabScrollY(), scrollYOffset)
 
   useEffect(() => {
     updateCurrentScrollY(scrollY)

--- a/src/elements/Tabs/hooks/useListenForTabContentScroll.tsx
+++ b/src/elements/Tabs/hooks/useListenForTabContentScroll.tsx
@@ -4,8 +4,8 @@ import { useScreenScrollContext } from "../../Screen/ScreenScrollContext"
 import { useAnimatedHeaderScrolling } from "../../Screen/hooks/useAnimatedHeaderScrolling"
 
 export const useListenForTabContentScroll = () => {
-  const scrollY = useAnimatedHeaderScrolling(useCurrentTabScrollY())
-  const { updateCurrentScrollY } = useScreenScrollContext()
+  const { updateCurrentScrollY, scrollYDetectionOffset } = useScreenScrollContext()
+  const scrollY = useAnimatedHeaderScrolling(useCurrentTabScrollY(), scrollYDetectionOffset)
 
   useEffect(() => {
     updateCurrentScrollY(scrollY)


### PR DESCRIPTION
This PR relates to  [https://artsyproduct.atlassian.net/browse/DIA-105] <!-- eg [PROJECT-XXXX] -->

### Description

The problem with the tabs is that tabs with big headers lose the scroll functionality to work 100% when the header is fully scrolled.
This PR adds an extra prop to the ScrollContext in order to allow the clients to set up the extra offsets for bigger header contents especially.

https://github.com/artsy/palette-mobile/assets/15792853/aa8e8938-9c5c-46ee-8752-2d077649a945

relates to https://github.com/artsy/eigen/pull/9219





