### PR TITLE
feat(Image): expose gemini resize mode from Image

### DIFF
--- a/src/elements/Image/Image.tsx
+++ b/src/elements/Image/Image.tsx
@@ -3,7 +3,7 @@ import { useState } from "react"
 import { PixelRatio } from "react-native"
 import FastImage, { FastImageProps } from "react-native-fast-image"
 import { Easing } from "react-native-reanimated"
-import { createGeminiUrl } from "../../utils/createGeminiUrl"
+import { GeminiResizeMode, createGeminiUrl } from "../../utils/createGeminiUrl"
 import { useColor } from "../../utils/hooks"
 import { useScreenDimensions } from "../../utils/hooks/useScreenDimensions"
 import { Flex } from "../Flex"
@@ -22,6 +22,8 @@ export interface ImageProps extends CustomFastImageProps {
   performResize?: boolean
   /** Source url to the image  */
   src: string
+  /** Gemini resize_to param  */
+  geminiResizeMode?: GeminiResizeMode
 }
 
 export const Image: React.FC<ImageProps> = ({
@@ -32,6 +34,7 @@ export const Image: React.FC<ImageProps> = ({
   src,
   style,
   resizeMode,
+  geminiResizeMode,
   ...flexProps
 }) => {
   const [loading, setLoading] = useState(true)
@@ -44,6 +47,7 @@ export const Image: React.FC<ImageProps> = ({
       imageURL: src,
       width: PixelRatio.getPixelSizeForLayoutSize(dimensions.width),
       height: PixelRatio.getPixelSizeForLayoutSize(dimensions.height),
+      resizeMode: geminiResizeMode,
     })
   }
 

--- a/src/utils/createGeminiUrl.ts
+++ b/src/utils/createGeminiUrl.ts
@@ -1,5 +1,7 @@
 import { Platform } from "react-native"
 
+export type GeminiResizeMode = "fit" | "fill"
+
 export function createGeminiUrl({
   imageURL,
   width,
@@ -13,7 +15,7 @@ export function createGeminiUrl({
   height: number
   geminiHost?: string
   imageQuality?: number
-  resizeMode?: "fit" | "fill"
+  resizeMode?: GeminiResizeMode
 }) {
   const src = encodeURIComponent(imageURL)
 


### PR DESCRIPTION
### Description

There's some discussion going on around the Image and Gemini params([here](https://artsy.slack.com/archives/C05EEBNEF71/p1694436720499889) and [here](https://artsy.slack.com/archives/C02BAQ5K7/p1690277621906139)), while that's not settled I'm exposing the Gemini resize_to param to fix some issues we're having because of the default `resize_to` to `fit`.
