### PR TITLE
fix(image): set default Gemini resize mode to `fill`

### DIFF
--- a/src/utils/createGeminiUrl.ts
+++ b/src/utils/createGeminiUrl.ts
@@ -8,7 +8,7 @@ export function createGeminiUrl({
   height,
   geminiHost = "d7hftxdivxxvm.cloudfront.net",
   imageQuality = 80,
-  resizeMode = "fit",
+  resizeMode = "fill",
 }: {
   imageURL: string
   width: number


### PR DESCRIPTION
This PR resolves [ONYX-358]

Co-authored by: @gkartalis 

### Description

This addresses some long-standing issues (see threads [here](https://artsy.slack.com/archives/C02BAQ5K7/p1690277621906139) and [here](https://artsy.slack.com/archives/C05EEBNEF71/p1694627963577869?thread_ts=1694436720.499889&cid=C05EEBNEF71)) related to the new `Image` component.

This changes the default behavior of the component, but luckily it's been barely used so far (and is accompanied by an [Eigen PR](https://github.com/artsy/eigen/pull/9263) to change the one usage of it over there).

Prior to this change, there was a mismatch between the [default contain/fit Image (via Gemini) resizing behavior](https://github.com/artsy/palette-mobile/blob/7d66047fd267899b6b2f46fb720b04394eb56b20/src/utils/createGeminiUrl.ts#L11) and the [default cover/fill FastImage behavior](https://github.com/DylanVann/react-native-fast-image#resizemode-enum), resulting in images that were undersized and low-res.

## Before

<img width="2560" alt="before1" src="https://github.com/artsy/palette-mobile/assets/140521/7f1cd4cc-dfc1-4643-97a1-db2f279c253a">

## After

<img width="2560" alt="after1" src="https://github.com/artsy/palette-mobile/assets/140521/d872a24f-f9b2-491a-aaf0-77d36e3d0898">




[ONYX-358]: https://artsyproduct.atlassian.net/browse/ONYX-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ