### PR TITLE
fix: progressive onboarding positioning on android

### DIFF
--- a/src/elements/Popover/Popover.tsx
+++ b/src/elements/Popover/Popover.tsx
@@ -1,5 +1,5 @@
 import { Color, THEME } from "@artsy/palette-tokens"
-import { ViewStyle } from "react-native"
+import { Platform, StatusBar, ViewStyle } from "react-native"
 import RNPopover from "react-native-popover-view"
 import { Easing } from "react-native-reanimated"
 import styled from "styled-components"
@@ -43,6 +43,8 @@ export const Popover = ({
       popoverStyle={[{ backgroundColor: style.backgroundColor }, style.shadow]}
       from={children}
       isVisible={visible}
+      // this is required to make sure that the popover is positioned correctly on android
+      verticalOffset={Platform.OS === "android" ? -(StatusBar.currentHeight ?? 0) : 0}
       onCloseComplete={onCloseComplete}
       onRequestClose={onPressOutside}
       placement={placement as RNPopover["props"]["placement"]}


### PR DESCRIPTION
This PR resolves [DIA-163] <!-- eg [PROJECT-XXXX] -->

### Description

This PR addresses an issue where the placement of the popover is broken on Android because of the status bar.
The above solution is inspired by the suggestion in `react-native-popover-view` docs

<img width="1243" alt="Screenshot 2023-09-19 at 17 57 25" src="https://github.com/artsy/palette-mobile/assets/11945712/478dc28a-f559-42c2-9919-eff2cb2660ee">


![Group 1 (5)](https://github.com/artsy/palette-mobile/assets/11945712/a0bb80b4-c8b6-4c24-b724-3c4f0db93650)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[DIA-163]: https://artsyproduct.atlassian.net/browse/DIA-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ