### PR TITLE
feat(Pill): adjust horizontal padding of profile variant

### DIFF
--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -131,7 +131,7 @@ const PILL_VARIANTS: Record<PillVariant, Record<PillState, FlattenInterpolation<
       border-color: ${themeGet("colors.black5")};
       border-radius: 25px;
       height: 50px;
-      padding: 0 ${themeGet("space.2")}};
+      padding: 0 ${themeGet("space.1")}};
     `,
     selected: css`
       border-color: ${themeGet("colors.blue100")};


### PR DESCRIPTION
### Description

Small UI correction in the profile variant, horizontal padding should be 1 instead of 2.

<img width="378" alt="image" src="https://github.com/artsy/palette-mobile/assets/15792853/02d63d50-b751-4812-9cde-0cac21bb44bd">

