### PR TITLE
fix: remove unnecessary padding from IconComponent in Message

### DIFF
--- a/src/elements/Message/Message.tsx
+++ b/src/elements/Message/Message.tsx
@@ -90,7 +90,7 @@ export const Message: React.FC<MessageProps> = ({
           </Flex>
 
           {!!IconComponent && iconPosition === "right" && (
-            <Flex mr={1} justifyContent="center">
+            <Flex mr={showCloseButton ? 1 : 0} justifyContent="center">
               <IconComponent />
             </Flex>
           )}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR removes the unnecessary padding from IconComponent in Message that gets added even there is no X icon shown.
![Group 1 (8)](https://github.com/artsy/palette-mobile/assets/11945712/030bdaf6-2846-47dd-a5ea-71fd8d983a37)

cc @dblandin 


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
