### PR TITLE
feat(Pill): adjusts the image overflow for profile variant

### DIFF
--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -62,7 +62,9 @@ export const Pill: React.FC<PillProps> = ({
         )}
       >
         {variant === "profile" && src && (
-          <Thumbnail src={src} height={30} width={30} style={{ overflow: "hidden" }} />
+          <Flex overflow="hidden" borderRadius={50} height={30} width={30} mr={1}>
+            <Thumbnail src={src} height={30} width={30} />
+          </Flex>
         )}
         {Icon && <Icon fill={color} ml={-0.5} mr={0.5} />}
 
@@ -97,8 +99,6 @@ const Container = styled(MotiPressable)<MotiPressableProps & PillProps>`
 
 const Thumbnail = styled(Image)`
   background-color: ${themeGet("colors.black30")};
-  border-radius: 50px;
-  margin-right: ${themeGet("space.1")};
 `
 
 const PILL_STATES = {


### PR DESCRIPTION
### Description

In Storybook not noticeable, but on Eigen we can see the square, this PR wraps the image with a View doing the masking.

Before:

https://github.com/artsy/palette-mobile/assets/15792853/0f0d712c-3e61-4d2a-afe2-c3418a7f7154

After(Storybook with slow animations feature from Simulator):

https://github.com/artsy/palette-mobile/assets/15792853/d129ebc5-44b4-4bd1-a556-bb75b9cc1733



