### PR TITLE
fix: make innerRef optional

### DIFF
--- a/src/elements/Tabs/TabMasonry.tsx
+++ b/src/elements/Tabs/TabMasonry.tsx
@@ -6,7 +6,7 @@ import { useSpace } from "../../utils/hooks/useSpace"
 
 export function TabMasonry<T>(
   props: MasonryFlashListProps<T> & {
-    innerRef?: RefObject<MasonryFlashListRef<T>> | null | undefined
+    innerRef?: RefObject<MasonryFlashListRef<T>> | null
   }
 ) {
   useListenForTabContentScroll()

--- a/src/elements/Tabs/TabMasonry.tsx
+++ b/src/elements/Tabs/TabMasonry.tsx
@@ -6,7 +6,7 @@ import { useSpace } from "../../utils/hooks/useSpace"
 
 export function TabMasonry<T>(
   props: MasonryFlashListProps<T> & {
-    innerRef: RefObject<MasonryFlashListRef<T>> | null | undefined
+    innerRef?: RefObject<MasonryFlashListRef<T>> | null | undefined
   }
 ) {
   useListenForTabContentScroll()


### PR DESCRIPTION
### Description
This PR brings fixes ot my previous PR. It makes the `innerRef` optional in order not to break types. I apologize for missing this

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
