### PR TITLE
Fix(ONYX-508): Fix vertical centering of text within pills

### DIFF
--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -68,7 +68,7 @@ export const Pill: React.FC<PillProps> = ({
         )}
         {Icon && <Icon fill={color} ml={-0.5} mr={0.5} />}
 
-        <Text variant="xs" color={color}>
+        <Text variant="xs" color={color} lineHeight={Icon ? "18px" : "15px"}>
           {children}
         </Text>
 

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -7,7 +7,7 @@ import { CloseIcon } from "../../svgs"
 import { IconProps } from "../../svgs/Icon"
 import { Flex, FlexProps } from "../Flex"
 import { Image } from "../Image"
-import { Text, useTextStyleForPalette } from "../Text"
+import { Text } from "../Text"
 
 export const PILL_VARIANT_NAMES = ["default", "search", "filter", "profile", "badge"] as const
 export type PillState = "default" | "selected" | "disabled"
@@ -37,7 +37,6 @@ export const Pill: React.FC<PillProps> = ({
   onPress,
   ...rest
 }) => {
-  const textStyle = useTextStyleForPalette("xs")
   const stateString = selected ? "selected" : disabled ? "disabled" : "default"
   const color = TEXT_COLOR[variant][stateString]
   const showCloseIcon =
@@ -69,7 +68,7 @@ export const Pill: React.FC<PillProps> = ({
         )}
         {Icon && <Icon fill={color} ml={-0.5} mr={0.5} />}
 
-        <Text style={textStyle} color={color}>
+        <Text variant="xs" color={color} style={{ marginBottom: 2 }}>
           {children}
         </Text>
 

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -7,7 +7,7 @@ import { CloseIcon } from "../../svgs"
 import { IconProps } from "../../svgs/Icon"
 import { Flex, FlexProps } from "../Flex"
 import { Image } from "../Image"
-import { Text } from "../Text"
+import { Text, useTextStyleForPalette } from "../Text"
 
 export const PILL_VARIANT_NAMES = ["default", "search", "filter", "profile", "badge"] as const
 export type PillState = "default" | "selected" | "disabled"
@@ -37,6 +37,7 @@ export const Pill: React.FC<PillProps> = ({
   onPress,
   ...rest
 }) => {
+  const textStyle = useTextStyleForPalette("xs")
   const stateString = selected ? "selected" : disabled ? "disabled" : "default"
   const color = TEXT_COLOR[variant][stateString]
   const showCloseIcon =
@@ -68,7 +69,7 @@ export const Pill: React.FC<PillProps> = ({
         )}
         {Icon && <Icon fill={color} ml={-0.5} mr={0.5} />}
 
-        <Text variant="xs" color={color} lineHeight={Icon ? "18px" : "15px"}>
+        <Text style={textStyle} color={color}>
           {children}
         </Text>
 


### PR DESCRIPTION
This PR resolves [ONYX-508] <!-- eg [PROJECT-XXXX] -->

### Description
Fixed vertical centering of text within pills

The text within the pill was not centred. In this PR I set the font weight for the text component to have either the default height of a custom left Icon (18px) or the height of the close icon (15px)

This PR changes only the text within the pill for the pills without the close button and pills with the close button (on the screenshot you can see the changes to lines 1, 2, 4, 5)

| Before | After |
| --- | --- |
| ![simulator_screenshot_1BD37656-E881-499C-8901-DC949E469AD2](https://github.com/artsy/palette-mobile/assets/36167539/10ecd849-f20e-4e1b-a0b2-dcc057d4af72) | ![simulator_screenshot_AAD14F12-C54E-4945-B966-A543EC1264DD](https://github.com/artsy/palette-mobile/assets/36167539/2c41828e-c5ab-425f-9cca-7e308a997ee7) |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[ONYX-508]: https://artsyproduct.atlassian.net/browse/ONYX-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ