### PR TITLE
fix: specify compatible kotlin version to avoid dup class error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 21
         compileSdkVersion = 31
         targetSdkVersion = 31
+        kotlinVersion = "1.6.10"
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes the android build duplicate class error by specifying kotlin version. 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
