### PR TITLE
feat: support dotted pill

### DIFF
--- a/src/elements/Pill/Pill.stories.tsx
+++ b/src/elements/Pill/Pill.stories.tsx
@@ -62,6 +62,16 @@ storiesOf("Pill", module)
       </Flex>
 
       <Flex flexDirection="row">
+        <Pill variant="search">Unique</Pill>
+        <Pill variant="search" selected ml={1}>
+          Painting
+        </Pill>
+        <Pill variant="search" disabled ml={1}>
+          Sculpture
+        </Pill>
+      </Flex>
+
+      <Flex flexDirection="row">
         <Pill variant="search">Search</Pill>
         <Pill variant="search" selected ml={1}>
           Selected

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -9,7 +9,14 @@ import { Flex, FlexProps } from "../Flex"
 import { Image } from "../Image"
 import { Text } from "../Text"
 
-export const PILL_VARIANT_NAMES = ["default", "search", "filter", "profile", "badge"] as const
+export const PILL_VARIANT_NAMES = [
+  "badge",
+  "default",
+  "dotted",
+  "filter",
+  "profile",
+  "search",
+] as const
 export type PillState = "default" | "selected" | "disabled"
 export type PillVariant = typeof PILL_VARIANT_NAMES[number]
 
@@ -21,7 +28,7 @@ export type PillProps = (FlexProps & {
 }) &
   (
     | {
-        variant?: Extract<PillVariant, "default" | "filter" | "badge" | "search">
+        variant?: Extract<PillVariant, "default" | "filter" | "badge" | "search" | "dotted">
         src?: never
       }
     | { variant: Extract<PillVariant, "profile">; src?: string }
@@ -88,6 +95,7 @@ const Container = styled(MotiPressable)<MotiPressableProps & PillProps>`
 
   ${(props) => {
     const states = PILL_VARIANTS[props.variant!]
+    console.log({ states })
 
     return css`
       ${states.default}
@@ -119,6 +127,13 @@ const PILL_STATES = {
 
 const PILL_VARIANTS: Record<PillVariant, Record<PillState, FlattenInterpolation<any>>> = {
   default: PILL_STATES,
+  dotted: {
+    ...PILL_STATES,
+    default: css`
+      ${PILL_STATES.default}
+      border-style: dashed;
+    `,
+  },
   search: {
     ...PILL_STATES,
     default: css`
@@ -174,6 +189,7 @@ const defaultColors: Record<PillState, Color> = {
 }
 const TEXT_COLOR: Record<PillVariant, Record<PillState, Color>> = {
   default: defaultColors,
+  dotted: defaultColors,
   search: defaultColors,
   profile: {
     ...defaultColors,

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -95,7 +95,6 @@ const Container = styled(MotiPressable)<MotiPressableProps & PillProps>`
 
   ${(props) => {
     const states = PILL_VARIANTS[props.variant!]
-    console.log({ states })
 
     return css`
       ${states.default}
@@ -132,6 +131,10 @@ const PILL_VARIANTS: Record<PillVariant, Record<PillState, FlattenInterpolation<
     default: css`
       ${PILL_STATES.default}
       border-style: dashed;
+    `,
+    selected: css`
+      background-color: ${themeGet("colors.blue10")};
+      border-color: ${themeGet("colors.blue10")};
     `,
   },
   search: {

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -133,8 +133,9 @@ const PILL_VARIANTS: Record<PillVariant, Record<PillState, FlattenInterpolation<
       border-style: dashed;
     `,
     selected: css`
-      background-color: ${themeGet("colors.blue10")};
-      border-color: ${themeGet("colors.blue10")};
+      ${PILL_STATES.selected}
+      background-color: ${themeGet("colors.black60")};
+      border-color: ${themeGet("colors.black60")};
     `,
   },
   search: {


### PR DESCRIPTION
This PR resolves [ONYX-536] <!-- eg [PROJECT-XXXX] -->

### Description

This ticket comes as an effort to bring in the dotted version of the pill to palette. This change has been approved by the design team and the same component will also be added to Force.

<img width="434" alt="Screenshot 2023-11-21 at 17 17 27" src="https://github.com/artsy/palette-mobile/assets/11945712/89f56d05-2db6-419d-a224-30b3a5a6e282">


**Not required yet:** Separate selected and disabled states

<img width="387" alt="Screenshot 2023-11-21 at 17 16 17" src="https://github.com/artsy/palette-mobile/assets/11945712/141fae81-1190-4cbe-bd81-43bf3bd60376">


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[ONYX-536]: https://artsyproduct.atlassian.net/browse/ONYX-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ