### PR TITLE
chore: support animated sticky sub header

### DIFF
--- a/src/elements/Screen/Screen.stories.tsx
+++ b/src/elements/Screen/Screen.stories.tsx
@@ -81,6 +81,29 @@ storiesOf("Screen", module)
     </Screen>
   ))
 
+  .add("FlatList With AnimatedHeader and StickySubHeader", () => (
+    <Screen>
+      <Screen.AnimatedHeader title="Title" />
+
+      <Screen.StickySubHeader title="Title">
+        <Flex width="100%" height={60} backgroundColor="red10" />
+      </Screen.StickySubHeader>
+
+      <Screen.Body>
+        <Screen.FlatList
+          data={Array.from({ length: 50 }).map((_, i) => "Item " + i)}
+          renderItem={({ item, index }) => {
+            return (
+              <Text my={1} key={index}>
+                {item}
+              </Text>
+            )
+          }}
+        />
+      </Screen.Body>
+    </Screen>
+  ))
+
   .add("Fullwidth", () => (
     <Screen>
       <Screen.Header title="Title" />

--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -1,0 +1,41 @@
+import { MotiView } from "moti"
+import React from "react"
+import { useScreenScrollContext } from "./ScreenScrollContext"
+import { NAVBAR_HEIGHT } from "./constants"
+import { Flex } from "../Flex"
+import { Separator } from "../Separator"
+import { Text } from "../Text"
+
+export interface SubHeaderProps extends React.PropsWithChildren<{}> {
+  title: string
+}
+
+const STICKY_BAR_HEIGHT = 60
+
+export const StickySubHeader: React.FC<SubHeaderProps> = ({ title, children }) => {
+  const { currentScrollY, scrollYOffset = 0 } = useScreenScrollContext()
+
+  const visible = currentScrollY >= NAVBAR_HEIGHT + scrollYOffset ? false : true
+
+  return (
+    <Flex>
+      <MotiView
+        animate={{
+          height: visible ? STICKY_BAR_HEIGHT : 0,
+          opacity: visible ? 1 : 0,
+          transform: [{ translateY: visible ? 0 : -STICKY_BAR_HEIGHT }],
+        }}
+        transition={{
+          type: "timing",
+          duration: 200,
+        }}
+      >
+        <Text variant="lg-display" numberOfLines={1} px={2}>
+          {title}
+        </Text>
+      </MotiView>
+      {children}
+      <Separator borderColor="black10" />
+    </Flex>
+  )
+}

--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -6,13 +6,13 @@ import { Flex } from "../Flex"
 import { Separator } from "../Separator"
 import { Text } from "../Text"
 
-export interface SubHeaderProps extends React.PropsWithChildren<{}> {
+export interface StickySubHeaderProps extends React.PropsWithChildren<{}> {
   title: string
 }
 
 const STICKY_BAR_HEIGHT = 60
 
-export const StickySubHeader: React.FC<SubHeaderProps> = ({ title, children }) => {
+export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, children }) => {
   const { currentScrollY, scrollYOffset = 0 } = useScreenScrollContext()
 
   const visible = currentScrollY >= NAVBAR_HEIGHT + scrollYOffset ? false : true

--- a/src/elements/Screen/index.tsx
+++ b/src/elements/Screen/index.tsx
@@ -9,6 +9,7 @@ import { ScreenBase } from "./ScreenBase"
 import { ScreenFlatList } from "./ScreenFlatList"
 import { ScreenScrollContextProvider, useScreenScrollContext } from "./ScreenScrollContext"
 import { ScreenScrollView } from "./ScreenScrollView"
+import { StickySubHeader } from "./StickySubHeader"
 
 export * from "./constants"
 
@@ -24,6 +25,7 @@ export const Screen = Object.assign(ScreenBase, {
   Header,
   ScreenScrollContextProvider,
   ScrollView: ScreenScrollView,
+  StickySubHeader: StickySubHeader,
 
   // Hooks
   useScreenScrollContext,


### PR DESCRIPTION
### Description
This PR extends the screen component with a sticky sub-header section that collapses. 

**Example:**

https://github.com/artsy/palette-mobile/assets/11945712/a6da238c-3ed6-4a2b-9fcf-7bc47539d1b1

**Updated story:**


https://github.com/artsy/palette-mobile/assets/11945712/86510ca2-eebb-4b1b-968d-46888362f854




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
