### PR TITLE
feat: support dynamic height for sticky tabs

### DIFF
--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -10,11 +10,12 @@ import { Text } from "../Text"
 
 export interface StickySubHeaderProps extends React.PropsWithChildren<{}> {
   title: string
+  subTitle?: string
 }
 
 const STICKY_BAR_HEIGHT = 52
 
-export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, children }) => {
+export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, subTitle, children }) => {
   const { currentScrollY, scrollYOffset = 0 } = useScreenScrollContext()
   const space = useSpace()
 
@@ -45,6 +46,11 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, childre
           <Text variant="lg-display" color="white100">
             {title}
           </Text>
+          {subTitle && (
+            <Text variant="xs" mt={0.5} color="white100">
+              {subTitle}
+            </Text>
+          )}
         </Flex>
       )}
 
@@ -60,9 +66,14 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, childre
         }}
       >
         {/* If we don't specify a height for the text, we will get text jumps as the parent component height changes  */}
-        <Text variant="lg-display" style={{ height: stickyBarHeight }}>
-          {title}
-        </Text>
+        <Flex style={{ height: stickyBarHeight }}>
+          <Text variant="lg-display">{title}</Text>
+          {subTitle && (
+            <Text variant="xs" mt={0.5}>
+              {subTitle}
+            </Text>
+          )}
+        </Flex>
       </MotiView>
 
       {children}

--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -46,7 +46,7 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, subTitl
           <Text variant="lg-display" color="white100">
             {title}
           </Text>
-          {subTitle && (
+          {!!subTitle && (
             <Text variant="xs" mt={0.5} color="white100">
               {subTitle}
             </Text>


### PR DESCRIPTION
### Description

This PR makes the following change to the sticky component
- Now the height is dynamic ;) no more custom heights, inject whatever component, and it will adjust dynamically and take that into account during the transition and the height animation
- Support of `subTitle` below the title

https://github.com/artsy/palette-mobile/assets/11945712/67d3ada8-e691-492e-b088-d093b1164697


https://github.com/artsy/palette-mobile/assets/11945712/ecbc53c4-0c96-4ed5-9ae1-920c9ff6ebd4


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
