### PR TITLE
feat(avatar): Fade in on load

### DIFF
--- a/src/elements/Avatar/Avatar.tsx
+++ b/src/elements/Avatar/Avatar.tsx
@@ -1,6 +1,14 @@
-import { ImgHTMLAttributes } from "react"
+import { ImgHTMLAttributes, useState } from "react"
 import { Image } from "react-native"
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+  Easing,
+  withDelay,
+} from "react-native-reanimated"
 import { useColor } from "../../utils/hooks"
+import { Box } from "../Box"
 import { Flex } from "../Flex"
 import { Text, TextProps } from "../Text"
 
@@ -39,22 +47,50 @@ const VARIANTS: Record<AvatarSize, { diameter: number; textSize: TextProps["vari
 /** A circular Avatar component containing an image or initials */
 export const Avatar = ({ src, initials, size = DEFAULT_SIZE }: AvatarProps) => {
   const color = useColor()
+  const [loading, setLoading] = useState(true)
+
+  const opacity = useSharedValue(0)
+
+  opacity.value = withDelay(
+    100,
+    withTiming(1, {
+      duration: 200,
+      easing: Easing.sin,
+    })
+  )
+
+  const style = useAnimatedStyle(() => {
+    return {
+      opacity: loading ? 0 : opacity.value,
+    }
+  }, [loading])
+
   const { diameter, textSize } = VARIANTS[size]
 
   if (src) {
     return (
-      <Image
-        resizeMode="cover"
-        style={{
-          width: diameter,
-          height: diameter,
-          borderRadius: diameter / 2,
-          borderColor: color("white100"),
-          borderWidth: 1,
-        }}
-        source={{ uri: src }}
-        accessibilityLabel="AvatarImage"
-      />
+      <Box
+        width={diameter}
+        height={diameter}
+        borderRadius={diameter / 2}
+        overflow="hidden"
+        borderColor={color("white100")}
+        borderWidth={1}
+      >
+        <Animated.View style={style}>
+          <Image
+            onLoadStart={() => setLoading(true)}
+            onLoadEnd={() => setLoading(false)}
+            resizeMode="cover"
+            source={{ uri: src }}
+            accessibilityLabel="AvatarImage"
+            style={{
+              width: diameter,
+              height: diameter,
+            }}
+          />
+        </Animated.View>
+      </Box>
     )
   }
 


### PR DESCRIPTION
### Description

Adds some polish to the avatar to match images elsewhere in the app, so that when things load it fades in. 

For some reason Moti locked up in a large list (tons of artists in folio), so just went with vanilla reanimated. 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.1.0--canary.180.1173.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@13.1.0--canary.180.1173.0
  # or 
  yarn add @artsy/palette-mobile@13.1.0--canary.180.1173.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
