### PR TITLE
feat(constants): Add global opacity setter

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,13 @@
  * Touch area box for UI elements
  */
 export const DEFAULT_HIT_SLOP = { top: 20, bottom: 20, left: 20, right: 20 }
+
+/**
+ * Default active opacity for elements that use Palette's <Touchable />
+ */
+export let DEFAULT_ACTIVE_OPACITY = 0.8
+
+// Set things globally
+export const setGlobalActiveOpacity = (opacity: number) => {
+  DEFAULT_ACTIVE_OPACITY = opacity
+}

--- a/src/elements/Touchable/Touchable.tsx
+++ b/src/elements/Touchable/Touchable.tsx
@@ -6,6 +6,7 @@ import {
   TouchableWithoutFeedback,
 } from "react-native"
 import Haptic, { HapticFeedbackTypes } from "react-native-haptic-feedback"
+import { DEFAULT_ACTIVE_OPACITY } from "../../constants"
 import { Color } from "../../types"
 import { useColor } from "../../utils/hooks/useColor"
 import { Flex } from "../Flex"
@@ -58,7 +59,7 @@ export const Touchable: React.FC<TouchableProps> = ({
   ) : (
     <TouchableHighlight
       underlayColor={underlayColor ?? "transparent"}
-      activeOpacity={0.8}
+      activeOpacity={DEFAULT_ACTIVE_OPACITY}
       {...props}
       onPress={onPressWrapped}
     >


### PR DESCRIPTION
### Description

This moves our `Touchable` active opacity setting into a constant, and exports a helper to set things globally. 

