### PR TITLE
feat: support gap columnGap and rowGap in Box, Flex

### DIFF
--- a/src/elements/Box/Box.stories.tsx
+++ b/src/elements/Box/Box.stories.tsx
@@ -47,17 +47,9 @@ const colors = ["red10", "green10", "yellow10", "devpurple", "red100", "black10"
 export const GapProps = () => (
   <List style={{ marginHorizontal: 20 }}>
     <Text>Gap 👇</Text>
-    <Box
-      borderWidth={1}
-      borderColor="black100"
-      rowGap={10}
-      columnGap={10}
-      // gap={10}
-      flexWrap="wrap"
-      flexDirection="row"
-    >
+    <Box borderWidth={1} borderColor="black100" gap={10} flexWrap="wrap" flexDirection="row">
       {colors.map((color) => (
-        <Box backgroundColor={color} width={100} height={100}>
+        <Box key={`${color}-1`} backgroundColor={color} width={100} height={100}>
           <Text>{color}</Text>
         </Box>
       ))}
@@ -66,7 +58,7 @@ export const GapProps = () => (
     <Text>Row gap 👇</Text>
     <Box borderWidth={1} borderColor="black100" rowGap={10} flexWrap="wrap" flexDirection="row">
       {colors.map((color) => (
-        <Box backgroundColor={color} width={100} height={100}>
+        <Box key={`${color}-2`} backgroundColor={color} width={100} height={100}>
           <Text>{color}</Text>
         </Box>
       ))}
@@ -75,7 +67,7 @@ export const GapProps = () => (
     <Text>Column gap 👇</Text>
     <Box borderWidth={1} borderColor="black100" columnGap={10} flexWrap="wrap" flexDirection="row">
       {colors.map((color) => (
-        <Box backgroundColor={color} width={100} height={100}>
+        <Box key={`${color}-3`} backgroundColor={color} width={100} height={100}>
           <Text>{color}</Text>
         </Box>
       ))}

--- a/src/elements/Box/Box.stories.tsx
+++ b/src/elements/Box/Box.stories.tsx
@@ -1,7 +1,10 @@
 import { useRef } from "react"
 import { View } from "react-native"
 import { List } from "../../storybook/helpers"
-import { Box, BoxProps } from "../Box"
+import { Box } from "../Box"
+import { Flex } from "../Flex"
+import { Spacer } from "../Spacer"
+import { Text } from "../Text"
 
 export default {
   title: "Box",
@@ -14,7 +17,8 @@ export const Styled = () => (
       px={1}
       backgroundColor="blue100"
       flexDirection="row"
-      height={30}
+      height={300}
+      width={200}
       top={2}
       borderBottomWidth={1}
       textAlign="center"
@@ -25,11 +29,58 @@ export const Styled = () => (
 export const RegularViewProps = () => {
   const r = useRef<View>(null)
   return (
-    <Box
-      px={1}
-      backgroundColor="red100"
-      onLayout={(e) => console.log(e.nativeEvent.layout)}
-      ref={r}
-    />
+    <Flex flex={1}>
+      <Box
+        px={1}
+        height={200}
+        width={200}
+        backgroundColor="red100"
+        onLayout={(e) => console.log(e.nativeEvent.layout)}
+        ref={r}
+      />
+    </Flex>
   )
 }
+
+const colors = ["red10", "green10", "yellow10", "devpurple", "red100", "black10"]
+
+export const GapProps = () => (
+  <List style={{ marginHorizontal: 20 }}>
+    <Text>Gap 👇</Text>
+    <Box
+      borderWidth={1}
+      borderColor="black100"
+      rowGap={10}
+      columnGap={10}
+      // gap={10}
+      flexWrap="wrap"
+      flexDirection="row"
+    >
+      {colors.map((color) => (
+        <Box backgroundColor={color} width={100} height={100}>
+          <Text>{color}</Text>
+        </Box>
+      ))}
+    </Box>
+
+    <Text>Row gap 👇</Text>
+    <Box borderWidth={1} borderColor="black100" rowGap={10} flexWrap="wrap" flexDirection="row">
+      {colors.map((color) => (
+        <Box backgroundColor={color} width={100} height={100}>
+          <Text>{color}</Text>
+        </Box>
+      ))}
+    </Box>
+
+    <Text>Column gap 👇</Text>
+    <Box borderWidth={1} borderColor="black100" columnGap={10} flexWrap="wrap" flexDirection="row">
+      {colors.map((color) => (
+        <Box backgroundColor={color} width={100} height={100}>
+          <Text>{color}</Text>
+        </Box>
+      ))}
+    </Box>
+
+    <Spacer y={6} />
+  </List>
+)

--- a/src/elements/Box/Box.tsx
+++ b/src/elements/Box/Box.tsx
@@ -1,5 +1,4 @@
 import { View, ViewProps, ViewStyle } from "react-native"
-import { css } from "styled-components"
 import styled from "styled-components/native"
 import {
   border,
@@ -25,12 +24,6 @@ type GapProps = {
   columnGap?: ViewStyle["columnGap"]
 }
 
-const gap = (props: GapProps) => css`
-  gap: ${props.gap}px;
-  column-gap: ${props.columnGap}px;
-  row-gap: ${props.rowGap}px;
-`
-
 export interface BoxProps
   extends ViewProps,
     SpaceProps<SpacingUnitsTheme>,
@@ -53,5 +46,4 @@ export const Box = styled(View)<BoxProps>`
   ${position}
   ${border}
   ${textAlign}
-  ${gap}
 `

--- a/src/elements/Box/Box.tsx
+++ b/src/elements/Box/Box.tsx
@@ -26,7 +26,7 @@ type GapProps = {
 }
 
 const gap = (props: GapProps) => css`
-  gap: ${props.gap};
+  gap: ${props.gap}px;
   column-gap: ${props.columnGap}px;
   row-gap: ${props.rowGap}px;
 `

--- a/src/elements/Box/Box.tsx
+++ b/src/elements/Box/Box.tsx
@@ -1,4 +1,5 @@
-import { View, ViewProps } from "react-native"
+import { View, ViewProps, ViewStyle } from "react-native"
+import { css } from "styled-components"
 import styled from "styled-components/native"
 import {
   border,
@@ -18,6 +19,18 @@ import {
 } from "styled-system"
 import { ColorsTheme, SpacingUnitsTheme } from "../../tokens"
 
+type GapProps = {
+  gap?: ViewStyle["gap"]
+  rowGap?: ViewStyle["rowGap"]
+  columnGap?: ViewStyle["columnGap"]
+}
+
+const gap = (props: GapProps) => css`
+  gap: ${props.gap};
+  column-gap: ${props.columnGap}px;
+  row-gap: ${props.rowGap}px;
+`
+
 export interface BoxProps
   extends ViewProps,
     SpaceProps<SpacingUnitsTheme>,
@@ -26,6 +39,7 @@ export interface BoxProps
     LayoutProps,
     PositionProps,
     BorderProps,
+    GapProps,
     TextAlignProps {}
 
 /**
@@ -39,4 +53,5 @@ export const Box = styled(View)<BoxProps>`
   ${position}
   ${border}
   ${textAlign}
+  ${gap}
 `


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Paired with @araujobarret on this:

Adds support for `gap`, `columnGap` and `rowGap` in `<Box />`, `<Flex />` now that we upgraded to `rn 72`

https://reactnative.dev/docs/flexbox#row-gap-column-gap-and-gap

|Screenshots||
|---|---|
|![Simulator Screenshot - iPhone 15 - 2024-02-09 at 12 35 59](https://github.com/artsy/palette-mobile/assets/21178754/b17321c1-d774-4659-9be3-48b38a10e4c8)|![Simulator Screenshot - iPhone 15 - 2024-02-09 at 12 36 31](https://github.com/artsy/palette-mobile/assets/21178754/bc86087b-9250-40f4-a7bd-a672deed6958)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
