### PR TITLE
fix(tabs): Fix padding on large title

### DIFF
--- a/src/elements/Tabs/TabsWithHeader.tsx
+++ b/src/elements/Tabs/TabsWithHeader.tsx
@@ -34,7 +34,7 @@ export const TabsWithHeader: React.FC<TabsWithHeaderProps> = ({
             return (
               <>
                 {!!showTitle && (
-                  <Flex my={1} pl={2} justifyContent="center" pointerEvents="none">
+                  <Flex my={1} px={2} justifyContent="center" pointerEvents="none">
                     <Text variant="lg-display" numberOfLines={2}>
                       {title}
                     </Text>


### PR DESCRIPTION
Fixes issue here: https://www.notion.so/artsy/2024-02-09-Folio-App-QA-version-3-0-0-iOS-build-2024-2-9-17-Android-build-234-f6070ceb820a441a8a940ffa201f6d55?p=e28964ca7488480997cc7d4b39dba262&pm=s 

<img width="410" alt="Screenshot 2024-02-10 at 6 38 13 PM" src="https://github.com/artsy/palette-mobile/assets/236943/4515b608-3dcf-4174-ab4f-b45b00ff403a">


