### PR TITLE
fix: disable width calculation if no long text is specified

### DIFF
--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -194,7 +194,7 @@ export const Button: React.FC<ButtonProps> = ({
                       This will result in us being able to use getByText over
                       getAllByText()[0] to select the buttons in the test environment.
                   */}
-                  {!__TEST__ && (
+                  {!__TEST__ && longestText && (
                     <MeasuredView setMeasuredState={setLongestTextMeasurements}>
                       <Text color="red" style={textStyle}>
                         {longestText ? longestText : children}
@@ -204,7 +204,7 @@ export const Button: React.FC<ButtonProps> = ({
                   <AnimatedText
                     style={[
                       {
-                        width: Math.ceil(longestTextMeasurements.width),
+                        width: longestText ? Math.ceil(longestTextMeasurements.width) : "auto",
                         color: springProps.textColor,
                         textDecorationLine: springProps.textDecorationLine,
                       },


### PR DESCRIPTION
This PR resolves [ONYX-760] <!-- eg [PROJECT-XXXX] -->

### Description

| Before | After |
| ------- | ------- |
| <Video src="https://github.com/artsy/palette-mobile/assets/11945712/de3e0c43-a858-44e2-b790-739726bc4aa0" /> |  <Video src="https://github.com/artsy/palette-mobile/assets/11945712/f9143074-9189-4af4-8d30-b4f76b2ad07c" /> |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[ONYX-760]: https://artsyproduct.atlassian.net/browse/ONYX-760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ