### PR TITLE
chore: Screen header improvements

### DIFF
--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -1,3 +1,4 @@
+import { MotiView } from "moti"
 import React from "react"
 import Animated, { Easing, FadeIn, FadeOut } from "react-native-reanimated"
 import { useScreenScrollContext } from "./ScreenScrollContext"
@@ -101,9 +102,15 @@ const Center: React.FC<{
         }}
       >
         <Flex alignItems="center" width="100%" {...titleProps}>
-          <Text variant="sm-display" numberOfLines={1}>
-            {title}
-          </Text>
+          <MotiView
+            animate={{
+              opacity: display === "flex" ? 1 : 0,
+            }}
+          >
+            <Text variant="sm-display" numberOfLines={1}>
+              {title}
+            </Text>
+          </MotiView>
         </Flex>
       </Animated.View>
     </Flex>

--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -26,11 +26,7 @@ export interface HeaderProps {
 }
 
 export const AnimatedHeader: React.FC<HeaderProps> = (props) => {
-  const { currentScrollY, scrollYOffset } = useScreenScrollContext()
-
-  return (
-    <Header scrollY={currentScrollY} scrollYOffset={scrollYOffset} animated={true} {...props} />
-  )
+  return <Header animated={true} {...props} />
 }
 
 export const Header: React.FC<HeaderProps> = ({
@@ -41,85 +37,9 @@ export const Header: React.FC<HeaderProps> = ({
   leftElements,
   onBack,
   rightElements,
-  scrollY = 0,
-  scrollYOffset = 0,
   title,
   titleProps = {},
 }) => {
-  const Left = () => {
-    if (hideLeftElements) {
-      return null
-    }
-
-    return (
-      <Flex pr={1} width={50}>
-        {leftElements ? (
-          <>{leftElements}</>
-        ) : (
-          // If no left elements passed, show back button
-          <Touchable onPress={onBack} underlayColor="transparent" hitSlop={DEFAULT_HIT_SLOP}>
-            <ArrowLeftIcon fill="onBackgroundHigh" top="2px" />
-          </Touchable>
-        )}
-
-        <Spacer x={1} />
-      </Flex>
-    )
-  }
-
-  const Center = () => {
-    if (hideTitle) {
-      return null
-    }
-
-    if (!animated) {
-      return (
-        <Flex flex={1} flexDirection="row">
-          <Flex alignItems="center" width="100%" {...titleProps}>
-            <Text variant="sm-display" numberOfLines={1}>
-              {title}
-            </Text>
-          </Flex>
-        </Flex>
-      )
-    }
-
-    // Show / hide the title to avoid rerenders, which retrigger the animation
-    const display = scrollY < NAVBAR_HEIGHT + scrollYOffset ? "none" : "flex"
-
-    return (
-      <Flex flex={1} flexDirection="row">
-        <Animated.View
-          entering={FadeIn.duration(400).easing(Easing.out(Easing.exp))}
-          exiting={FadeOut.duration(400).easing(Easing.out(Easing.exp))}
-          style={{
-            display,
-            flex: 1,
-          }}
-        >
-          <Flex alignItems="center" width="100%" {...titleProps}>
-            <Text variant="sm-display" numberOfLines={1}>
-              {title}
-            </Text>
-          </Flex>
-        </Animated.View>
-      </Flex>
-    )
-  }
-
-  const Right = () => {
-    if (hideRightElements) {
-      return null
-    }
-
-    return (
-      <Flex width={50} alignItems="flex-end">
-        <Spacer x={1} />
-        {rightElements}
-      </Flex>
-    )
-  }
-
   return (
     <Flex
       height={NAVBAR_HEIGHT}
@@ -131,9 +51,81 @@ export const Header: React.FC<HeaderProps> = ({
       alignItems="center"
       width="100%"
     >
-      <Left />
-      <Center />
-      <Right />
+      {!hideLeftElements && <Left leftElements={leftElements} onBack={onBack} />}
+
+      {!hideTitle && <Center animated={animated} titleProps={titleProps} title={title} />}
+      {!hideRightElements && !!rightElements && <Right rightElements={rightElements} />}
+    </Flex>
+  )
+}
+
+const Right: React.FC<{ rightElements: React.ReactNode }> = ({ rightElements }) => {
+  return (
+    <Flex width={50} alignItems="flex-end">
+      <Spacer x={1} />
+      {rightElements}
+    </Flex>
+  )
+}
+
+const Center: React.FC<{
+  animated: boolean
+  titleProps: HeaderProps["titleProps"]
+  title: HeaderProps["title"]
+}> = ({ animated, titleProps, title }) => {
+  const { scrollYOffset = 0, currentScrollY = 0 } = useScreenScrollContext()
+
+  if (!animated) {
+    return (
+      <Flex flex={1} flexDirection="row">
+        <Flex alignItems="center" width="100%" {...titleProps}>
+          <Text variant="sm-display" numberOfLines={1}>
+            {title}
+          </Text>
+        </Flex>
+      </Flex>
+    )
+  }
+
+  // Show / hide the title to avoid rerenders, which retrigger the animation
+  const display = currentScrollY < NAVBAR_HEIGHT + scrollYOffset ? "none" : "flex"
+
+  return (
+    <Flex flex={1} flexDirection="row">
+      <Animated.View
+        entering={FadeIn.duration(400).easing(Easing.out(Easing.exp))}
+        exiting={FadeOut.duration(400).easing(Easing.out(Easing.exp))}
+        style={{
+          display,
+          flex: 1,
+        }}
+      >
+        <Flex alignItems="center" width="100%" {...titleProps}>
+          <Text variant="sm-display" numberOfLines={1}>
+            {title}
+          </Text>
+        </Flex>
+      </Animated.View>
+    </Flex>
+  )
+}
+
+const Left: React.FC<{
+  leftElements: HeaderProps["leftElements"]
+  onBack: HeaderProps["onBack"]
+}> = ({ leftElements, onBack }) => {
+  return (
+    <Flex pr={1} width={50}>
+      {leftElements ? (
+        <>{leftElements}</>
+      ) : (
+        // If no left elements passed, show back button
+        <Touchable onPress={onBack} underlayColor="transparent" hitSlop={DEFAULT_HIT_SLOP}>
+          <ArrowLeftIcon fill="onBackgroundHigh" top="2px" />
+        </Touchable>
+      )}
+
+      <Spacer x={1} />
     </Flex>
   )
 }

--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -1,6 +1,7 @@
 import { MotiView } from "moti"
 import React, { useState } from "react"
 import { LayoutChangeEvent } from "react-native"
+import { useDerivedValue } from "react-native-reanimated"
 import { useScreenScrollContext } from "./ScreenScrollContext"
 import { NAVBAR_HEIGHT } from "./constants"
 import { useSpace } from "../../utils/hooks"
@@ -20,7 +21,13 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, subTitl
   const space = useSpace()
 
   const [stickyBarHeight, setStickyHeaderHeight] = useState<null | number>(null)
-  const visible = currentScrollY >= NAVBAR_HEIGHT + scrollYOffset ? false : true
+
+  const visible = useDerivedValue(() => {
+    if (stickyBarHeight === null) {
+      return true
+    }
+    return currentScrollY >= NAVBAR_HEIGHT + scrollYOffset
+  })
 
   const handleLayout = (event: LayoutChangeEvent) => {
     setStickyHeaderHeight(event.nativeEvent.layout.height)
@@ -28,7 +35,6 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, subTitl
 
   // The styles are kept in a variable to make sure they're always in sync with the hidden text component
   const styles = {
-    paddingVertical: visible ? space(1) : 0,
     paddingHorizontal: space(2),
   }
 
@@ -43,21 +49,23 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, subTitl
           zIndex={-1000}
           style={styles}
         >
-          <Text variant="lg-display" color="white100">
-            {title}
-          </Text>
-          {!!subTitle && (
-            <Text variant="xs" mt={0.5} color="white100">
-              {subTitle}
+          <Flex mb={1}>
+            <Text variant="lg-display" color="white100">
+              {title}
             </Text>
-          )}
+            {!!subTitle && (
+              <Text variant="xs" mt={0.5} color="white100">
+                {subTitle}
+              </Text>
+            )}
+          </Flex>
         </Flex>
       )}
 
       <MotiView
         animate={{
-          height: visible ? stickyBarHeight || undefined : 0,
-          transform: [{ translateY: visible ? 0 : -(stickyBarHeight || STICKY_BAR_HEIGHT) }],
+          height: visible.value ? stickyBarHeight || undefined : 0,
+          transform: [{ translateY: visible.value ? 0 : -(stickyBarHeight || STICKY_BAR_HEIGHT) }],
         }}
         style={styles}
         transition={{
@@ -66,13 +74,19 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, subTitl
         }}
       >
         {/* If we don't specify a height for the text, we will get text jumps as the parent component height changes  */}
-        <Flex style={{ height: stickyBarHeight }}>
-          <Text variant="lg-display">{title}</Text>
-          {subTitle && (
-            <Text variant="xs" mt={0.5}>
-              {subTitle}
-            </Text>
-          )}
+        <Flex style={{ height: stickyBarHeight }} mb={1}>
+          <MotiView
+            animate={{
+              opacity: visible.value ? 1 : 0,
+            }}
+          >
+            <Text variant="lg-display">{title}</Text>
+            {subTitle && (
+              <Text variant="xs" mt={0.5}>
+                {subTitle}
+              </Text>
+            )}
+          </MotiView>
         </Flex>
       </MotiView>
 

--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -28,7 +28,7 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, subTitl
 
   // The styles are kept in a variable to make sure they're always in sync with the hidden text component
   const styles = {
-    paddingVertical: space(1),
+    paddingVertical: visible ? space(1) : 0,
     paddingHorizontal: space(2),
   }
 


### PR DESCRIPTION
### Description

This PR makes some improvements to our screen header components:
- Move as much as possible animations logic to the UI thread
- Fix broken padding on Screen.Header
- Separate Header components to avoid re-renders (Left, Center, Right)



https://github.com/artsy/palette-mobile/assets/11945712/489ae5f7-cd88-4a05-8cdc-ce20f5fcbc53


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.1.5--canary.188.1300.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@13.1.5--canary.188.1300.0
  # or 
  yarn add @artsy/palette-mobile@13.1.5--canary.188.1300.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
