### PR TITLE
fix: content jump after switching tabs

### DIFF
--- a/src/elements/LazyFlatlist/useHasSeenItem.tsx
+++ b/src/elements/LazyFlatlist/useHasSeenItem.tsx
@@ -7,7 +7,7 @@ export const useHasSeenItem = <T,>({ keyExtractor }: { keyExtractor: (item: T) =
 
   const viewabilityConfig = useRef<ViewabilityConfig>({
     // Percent of of the item that is visible for a partially occluded item to count as "viewable"
-    itemVisiblePercentThreshold: 80,
+    itemVisiblePercentThreshold: 20,
     minimumViewTime: 300,
     waitForInteraction: false,
   }).current


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes a jump on the content when switching between tabs on the activity screen. The behaviour we want to support can not be done with Moti and I had to therefore use reanimated instead

**Before**

https://github.com/artsy/palette-mobile/assets/11945712/565ea78a-58a7-4302-b697-7570f82418b4


**After**

https://github.com/artsy/palette-mobile/assets/11945712/079e5d57-c0cb-4b5e-b312-4ade313acc86



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
