### PR TITLE
fix: title centering when no right element is present

### DIFF
--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -52,15 +52,21 @@ export const Header: React.FC<HeaderProps> = ({
       alignItems="center"
       width="100%"
     >
-      {!hideLeftElements && <Left leftElements={leftElements} onBack={onBack} />}
-
-      {!hideTitle && <Center animated={animated} titleProps={titleProps} title={title} />}
-      {!hideRightElements && !!rightElements && <Right rightElements={rightElements} />}
+      <Left leftElements={leftElements} onBack={onBack} hideLeftElements={hideLeftElements} />
+      <Center animated={animated} titleProps={titleProps} title={title} hideTitle={hideTitle} />
+      <Right rightElements={rightElements} hideRightElements={hideRightElements} />
     </Flex>
   )
 }
 
-const Right: React.FC<{ rightElements: React.ReactNode }> = ({ rightElements }) => {
+const Right: React.FC<{
+  hideRightElements: HeaderProps["hideRightElements"]
+  rightElements: React.ReactNode
+}> = ({ hideRightElements, rightElements }) => {
+  if (hideRightElements) {
+    return null
+  }
+
   return (
     <Flex width={50} alignItems="flex-end">
       <Spacer x={1} />
@@ -71,14 +77,19 @@ const Right: React.FC<{ rightElements: React.ReactNode }> = ({ rightElements }) 
 
 const Center: React.FC<{
   animated: boolean
+  hideTitle: HeaderProps["hideTitle"]
   titleProps: HeaderProps["titleProps"]
   title: HeaderProps["title"]
-}> = ({ animated, titleProps, title }) => {
+}> = ({ animated, hideTitle, titleProps, title }) => {
   const { scrollYOffset = 0, currentScrollY = 0 } = useScreenScrollContext()
+
+  if (hideTitle) {
+    return null
+  }
 
   if (!animated) {
     return (
-      <Flex flex={1} flexDirection="row">
+      <Flex flex={1} flexDirection="row" width="100%">
         <Flex alignItems="center" width="100%" {...titleProps}>
           <Text variant="sm-display" numberOfLines={1}>
             {title}
@@ -118,9 +129,14 @@ const Center: React.FC<{
 }
 
 const Left: React.FC<{
+  hideLeftElements: HeaderProps["hideLeftElements"]
   leftElements: HeaderProps["leftElements"]
   onBack: HeaderProps["onBack"]
-}> = ({ leftElements, onBack }) => {
+}> = ({ hideLeftElements, leftElements, onBack }) => {
+  if (hideLeftElements) {
+    return null
+  }
+
   return (
     <Flex pr={1} width={50}>
       {leftElements ? (


### PR DESCRIPTION
### Description

This PR fixes an issue where the title is not centered if there is no right element provided.

For some reason we specify `hideTitle` and `hideRightElements` as props, which doesn't make much sense to me because I think if you don't want to show an element, simply pass nothing. Anyway, here i am bring this to how it was before my previous changes

**Before**
<img width="371" alt="Screenshot 2024-02-21 at 12 46 21" src="https://github.com/artsy/palette-mobile/assets/11945712/8e191c62-16c3-4398-8a9b-488c942f0f65">



**After**

https://github.com/artsy/palette-mobile/assets/11945712/96453a65-cb3e-4eb7-ad9f-283104c3eb67



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
