### PR TITLE
fix: opacity animation in android

### DIFF
--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -79,20 +79,12 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({ title, subTitl
       <Animated.View style={[sharedStyles, animatedStyles]}>
         {/* If we don't specify a height for the text, we will get text jumps as the parent component height changes  */}
         <Flex style={{ height: stickyBarHeight }} mb={1}>
-          <Animated.View
-            style={{
-              opacity: withTiming(visible.value ? 1 : 0, {
-                duration: 100,
-              }),
-            }}
-          >
-            <Text variant="lg-display">{title}</Text>
-            {subTitle && (
-              <Text variant="xs" mt={0.5}>
-                {subTitle}
-              </Text>
-            )}
-          </Animated.View>
+          <Text variant="lg-display">{title}</Text>
+          {subTitle && (
+            <Text variant="xs" mt={0.5}>
+              {subTitle}
+            </Text>
+          )}
         </Flex>
       </Animated.View>
 


### PR DESCRIPTION
### Description

**Sentry error:** https://artsynet.sentry.io/issues/?project=5867225&query=release%3Aandroid-8.33.0-1674645599+error.unhandled%3Atrue&sort=freq&statsPeriod=7d
**Thread:** https://artsy.slack.com/archives/C02BAQ5K7/p1708523668642899?thread_ts=1708517375.346149&cid=C02BAQ5K7

This PR fixes an issue affecting android and leading to break the screen component in Android

https://github.com/artsy/palette-mobile/assets/11945712/7374bad2-1d30-4f24-aeb9-45af73406903



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
