### PR TITLE
chore: upgrade react-native-blurhash

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -386,7 +386,8 @@ PODS:
   - React-jsinspector (0.72.10)
   - React-logger (0.72.10):
     - glog
-  - react-native-blurhash (1.1.11):
+  - react-native-blurhash (2.0.0):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
   - react-native-flipper (0.178.1):
     - React-Core
@@ -799,7 +800,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 45ef2ec6dcde31b90469175ec76ddac77b91dfc3
   React-jsinspector: de0198127395fec3058140a20c045167f761bb16
   React-logger: dc3a2b174d79c2da635059212747d8d929b54e06
-  react-native-blurhash: a59e6bf8117a0304488ed576abd440f4b0777a8c
+  react-native-blurhash: 684ec1be4719536f3f90129c7f6e3c6941768652
   react-native-flipper: a171cbd0bbc75544b0061d8e9f035e87d5233104
   react-native-pager-view: 0ccb8bf60e2ebd38b1f3669fa3650ecce81db2df
   react-native-safe-area-context: 39c2d8be3328df5d437ac1700f4f3a4f75716acc

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.21",
     "moti": "^0.25.3",
     "react-nanny": "^2.15.0",
-    "react-native-blurhash": "^1.1.11",
+    "react-native-blurhash": "^2.0.0",
     "react-native-collapsible-tab-view": "6.2.1",
     "react-native-fast-image": "^8.6.3",
     "react-native-pager-view": "^6.2.0",
@@ -55,12 +55,12 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
+    "react-native-blurhash": "^2.0.0",
     "react-native-haptic-feedback": "*",
     "react-native-linear-gradient": "*",
     "react-native-reanimated": "*",
     "react-native-svg": "*",
-    "styled-components": ">= 5",
-    "react-native-blurhash": "^1.1.11"
+    "styled-components": ">= 5"
   },
   "devDependencies": {
     "@artsy/auto-config": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9912,10 +9912,10 @@ react-nanny@^2.15.0:
   resolved "https://registry.yarnpkg.com/react-nanny/-/react-nanny-2.15.0.tgz#9472984af45761263b92b209f925e773fd761653"
   integrity sha512-fn6tAnJ+UEdD0pq5YytlZJb5XmjVcvXoxq3i2r1o/BavgipwRWsw7oOXNJ8bJd33iedlkNyAQMXVC6qTl0Hv4A==
 
-react-native-blurhash@^1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/react-native-blurhash/-/react-native-blurhash-1.1.11.tgz#cef102cc0239eb30c184235caf3fcb0b1f3ce33d"
-  integrity sha512-lYFf0C6vBz+wr5p81ABlzT9vSWmg4qTrtYGObBzhPOFIM8T0BHXbz0cCIE/gWgKFohLEWrwXFQ78GgHLlw7Jig==
+react-native-blurhash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-blurhash/-/react-native-blurhash-2.0.0.tgz#6c287836e107d3f89c77b2889c501af1f44af0db"
+  integrity sha512-sG63TByvMTRzZQ2oLPfBhGPBzKmnZiaF0A4CEIyRPjKVEKj++S6TT9J5PaXB8GkRNKHKLMo26bGVxLNYMaLmvA==
 
 react-native-collapsible-tab-view@6.2.1:
   version "6.2.1"


### PR DESCRIPTION
### Description

React-native-blurhash was released while we were working on the blurhash, nothing new apart from supporting the new arch, which we don't support. 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
