### PR TITLE
fix: show separator properly

### DIFF
--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -15,7 +15,7 @@ export interface StickySubHeaderProps extends React.PropsWithChildren<{}> {
 }
 
 const STICKY_BAR_HEIGHT = 42
-const DEFAULT_SEPARATOR_COMPONENT = <Separator borderColor="black10" />
+const DEFAULT_SEPARATOR_COMPONENT = <Separator borderColor="black5" />
 
 export const StickySubHeader: React.FC<StickySubHeaderProps> = ({
   title,
@@ -97,7 +97,8 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({
 
       {children}
 
-      {separatorComponent}
+      {/* check if children are defined, return children below */}
+      {children !== undefined && separatorComponent}
     </Flex>
   )
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR updates the default color of the separator and removes it if there are no children specified.
We have been getting QA comments on this once every two weeks, I hope this is the last time we get to update this.

![Simulator Screenshot - iPhone 15 Pro - 2024-02-27 at 11 49 32](https://github.com/artsy/palette-mobile/assets/11945712/89486950-c1a0-4bdd-8fd3-d7eb5fb44328)

![Simulator Screenshot - iPhone 15 Pro - 2024-02-27 at 11 49 28](https://github.com/artsy/palette-mobile/assets/11945712/c07830ee-8cbe-462e-bb49-39ad8156171c)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
