### PR TITLE
fix: Align right header element correctly

### DIFF
--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_HIT_SLOP } from "../../constants"
 import { ArrowLeftIcon } from "../../svgs/ArrowLeftIcon"
 import { useScreenDimensions } from "../../utils/hooks"
 import { Flex, FlexProps } from "../Flex"
+import { Spacer } from "../Spacer"
 import { Text } from "../Text"
 import { Touchable } from "../Touchable"
 
@@ -56,9 +57,8 @@ export const Header: React.FC<HeaderProps> = ({
       justifyContent="space-between"
       alignItems="center"
     >
-      <Center animated={animated} titleProps={titleProps} title={title} hideTitle={hideTitle} />
-
       <Left leftElements={leftElements} onBack={onBack} hideLeftElements={hideLeftElements} />
+      <Center animated={animated} titleProps={titleProps} title={title} hideTitle={hideTitle} />
       <Right rightElements={rightElements} hideRightElements={hideRightElements} />
     </Flex>
   )
@@ -105,6 +105,7 @@ const Center: React.FC<{
   title: HeaderProps["title"]
 }> = ({ animated, hideTitle, titleProps, title }) => {
   const { scrollYOffset = 0, currentScrollY = 0 } = useScreenScrollContext()
+  const { width: screenWidth } = useScreenDimensions()
 
   if (hideTitle) {
     return null
@@ -112,13 +113,8 @@ const Center: React.FC<{
 
   if (!animated) {
     return (
-      <Flex
-        position="absolute"
-        left="50%"
-        style={{ transform: "translateX(-50%)" }}
-        flexDirection="row"
-      >
-        <Flex alignItems="center" {...titleProps}>
+      <Flex position="absolute" left={0} flexDirection="row" minWidth={screenWidth}>
+        <Flex alignItems="center" width="100%" {...titleProps}>
           <Text variant="sm-display" numberOfLines={1}>
             {title}
           </Text>

--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -5,8 +5,8 @@ import { useScreenScrollContext } from "./ScreenScrollContext"
 import { NAVBAR_HEIGHT, ZINDEX } from "./constants"
 import { DEFAULT_HIT_SLOP } from "../../constants"
 import { ArrowLeftIcon } from "../../svgs/ArrowLeftIcon"
+import { useScreenDimensions } from "../../utils/hooks"
 import { Flex, FlexProps } from "../Flex"
-import { Spacer } from "../Spacer"
 import { Text } from "../Text"
 import { Touchable } from "../Touchable"
 
@@ -41,6 +41,8 @@ export const Header: React.FC<HeaderProps> = ({
   title,
   titleProps = {},
 }) => {
+  const screenWidth = useScreenDimensions().width
+
   return (
     <Flex
       height={NAVBAR_HEIGHT}
@@ -49,12 +51,38 @@ export const Header: React.FC<HeaderProps> = ({
       py={1}
       zIndex={ZINDEX.header}
       backgroundColor="background"
+      width={screenWidth}
+      position="relative"
+      justifyContent="space-between"
       alignItems="center"
-      width="100%"
     >
-      <Left leftElements={leftElements} onBack={onBack} hideLeftElements={hideLeftElements} />
       <Center animated={animated} titleProps={titleProps} title={title} hideTitle={hideTitle} />
+
+      <Left leftElements={leftElements} onBack={onBack} hideLeftElements={hideLeftElements} />
       <Right rightElements={rightElements} hideRightElements={hideRightElements} />
+    </Flex>
+  )
+}
+
+const Left: React.FC<{
+  hideLeftElements: HeaderProps["hideLeftElements"]
+  leftElements: HeaderProps["leftElements"]
+  onBack: HeaderProps["onBack"]
+}> = ({ hideLeftElements, leftElements, onBack }) => {
+  if (hideLeftElements) {
+    return null
+  }
+
+  return (
+    <Flex alignItems="center">
+      {leftElements ? (
+        <>{leftElements}</>
+      ) : (
+        // If no left elements passed, show back button
+        <Touchable onPress={onBack} underlayColor="transparent" hitSlop={DEFAULT_HIT_SLOP}>
+          <ArrowLeftIcon fill="onBackgroundHigh" />
+        </Touchable>
+      )}
     </Flex>
   )
 }
@@ -67,12 +95,7 @@ const Right: React.FC<{
     return null
   }
 
-  return (
-    <Flex width={50} alignItems="flex-end">
-      <Spacer x={1} />
-      {rightElements}
-    </Flex>
-  )
+  return <Flex alignItems="center">{rightElements}</Flex>
 }
 
 const Center: React.FC<{
@@ -89,8 +112,13 @@ const Center: React.FC<{
 
   if (!animated) {
     return (
-      <Flex flex={1} flexDirection="row" width="100%">
-        <Flex alignItems="center" width="100%" {...titleProps}>
+      <Flex
+        position="absolute"
+        left="50%"
+        style={{ transform: "translateX(-50%)" }}
+        flexDirection="row"
+      >
+        <Flex alignItems="center" {...titleProps}>
           <Text variant="sm-display" numberOfLines={1}>
             {title}
           </Text>
@@ -103,7 +131,7 @@ const Center: React.FC<{
   const display = currentScrollY < NAVBAR_HEIGHT + scrollYOffset ? "none" : "flex"
 
   return (
-    <Flex flex={1} flexDirection="row">
+    <Flex flexDirection="row">
       <Animated.View
         entering={FadeIn.duration(400).easing(Easing.out(Easing.exp))}
         exiting={FadeOut.duration(400).easing(Easing.out(Easing.exp))}
@@ -124,31 +152,6 @@ const Center: React.FC<{
           </MotiView>
         </Flex>
       </Animated.View>
-    </Flex>
-  )
-}
-
-const Left: React.FC<{
-  hideLeftElements: HeaderProps["hideLeftElements"]
-  leftElements: HeaderProps["leftElements"]
-  onBack: HeaderProps["onBack"]
-}> = ({ hideLeftElements, leftElements, onBack }) => {
-  if (hideLeftElements) {
-    return null
-  }
-
-  return (
-    <Flex pr={1} width={50}>
-      {leftElements ? (
-        <>{leftElements}</>
-      ) : (
-        // If no left elements passed, show back button
-        <Touchable onPress={onBack} underlayColor="transparent" hitSlop={DEFAULT_HIT_SLOP}>
-          <ArrowLeftIcon fill="onBackgroundHigh" top="2px" />
-        </Touchable>
-      )}
-
-      <Spacer x={1} />
     </Flex>
   )
 }

--- a/src/elements/Skeleton/Skeleton.tsx
+++ b/src/elements/Skeleton/Skeleton.tsx
@@ -35,7 +35,7 @@ export const SkeletonText: FC<TextProps> = ({ children, ...rest }) => {
 
   return (
     <Flex alignSelf="flex-start">
-      <Text {...rest} bg={color("black10")} color={color("black10")}>
+      <Text {...rest} bg={color("black10")} color={color("rgba(0, 0, 0, 0)")}>
         {children}
       </Text>
     </Flex>

--- a/src/elements/Skeleton/Skeleton.tsx
+++ b/src/elements/Skeleton/Skeleton.tsx
@@ -35,7 +35,7 @@ export const SkeletonText: FC<TextProps> = ({ children, ...rest }) => {
 
   return (
     <Flex alignSelf="flex-start">
-      <Text {...rest} bg={color("black10")} color={color("rgba(0, 0, 0, 0)")}>
+      <Text {...rest} bg={color("black10")} color={color("black10")}>
         {children}
       </Text>
     </Flex>


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

Resolves https://www.notion.so/artsy/Manage-saves-font-looks-broken-on-the-offer-page-update-font-size-according-to-design-and-center-bu-b344bd5a99f941fea5df5d4048679090?pvs=4

- Related Eigen PR: https://github.com/artsy/eigen/pull/9928

### Description

This pull request corrects the text alignment and centering in the screen header component.

| Before | After |
| --- | --- |
|![Simulator Screenshot - iPhone 15 Pro - 2024-03-04 at 16 10 10](https://github.com/artsy/eigen/assets/4691889/fb300647-3638-4073-8ab2-15cea781566e) | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-04 at 15 55 22](https://github.com/artsy/eigen/assets/4691889/6f8bbea1-aebf-40a1-890c-014dcd0e70a8)|

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.1.18--canary.200.1559.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@13.1.18--canary.200.1559.0
  # or 
  yarn add @artsy/palette-mobile@13.1.18--canary.200.1559.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
