### PR TITLE
fix: Update disabled switch colors for iOS

### DIFF
--- a/src/elements/Switch/Switch.tsx
+++ b/src/elements/Switch/Switch.tsx
@@ -52,7 +52,7 @@ export const Switch = ({
     thumbColor = Platform.OS === "ios" ? color("white100") : color("black30")
     trackColor = {
       false: color("black10"),
-      true: color("black10"),
+      true: Platform.OS === "ios" ? color("black30") : color("black10"),
     }
     iosBackground = color("black10")
   }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR updates the disabled switch color for iOS

| Before | After |
|---|---|
| ![image](https://github.com/artsy/palette-mobile/assets/20655703/2822fff3-57d9-48e0-85fa-97c652b4b8c3) | ![image](https://github.com/artsy/palette-mobile/assets/20655703/7bb54fd1-0039-456a-8791-991ceb49d099) |


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
