### PR TITLE
fix: Screen header element styling

### DIFF
--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -6,7 +6,6 @@ import { NAVBAR_HEIGHT, ZINDEX } from "./constants"
 import { DEFAULT_HIT_SLOP } from "../../constants"
 import { ArrowLeftIcon } from "../../svgs/ArrowLeftIcon"
 import { Flex, FlexProps } from "../Flex"
-import { Spacer } from "../Spacer"
 import { Text } from "../Text"
 import { Touchable } from "../Touchable"
 
@@ -68,8 +67,7 @@ const Right: React.FC<{
   }
 
   return (
-    <Flex width={50} alignItems="flex-end">
-      <Spacer x={1} />
+    <Flex flex={1} alignItems="flex-end">
       {rightElements}
     </Flex>
   )
@@ -89,12 +87,10 @@ const Center: React.FC<{
 
   if (!animated) {
     return (
-      <Flex flex={1} flexDirection="row" width="100%">
-        <Flex alignItems="center" width="100%" {...titleProps}>
-          <Text variant="sm-display" numberOfLines={1}>
-            {title}
-          </Text>
-        </Flex>
+      <Flex alignItems="center" {...titleProps}>
+        <Text variant="sm-display" numberOfLines={1}>
+          {title}
+        </Text>
       </Flex>
     )
   }
@@ -103,7 +99,7 @@ const Center: React.FC<{
   const display = currentScrollY < NAVBAR_HEIGHT + scrollYOffset ? "none" : "flex"
 
   return (
-    <Flex flex={1} flexDirection="row">
+    <Flex flexDirection="row">
       <Animated.View
         entering={FadeIn.duration(400).easing(Easing.out(Easing.exp))}
         exiting={FadeOut.duration(400).easing(Easing.out(Easing.exp))}
@@ -112,7 +108,7 @@ const Center: React.FC<{
           flex: 1,
         }}
       >
-        <Flex alignItems="center" width="100%" {...titleProps}>
+        <Flex alignItems="center" {...titleProps}>
           <MotiView
             animate={{
               opacity: display === "flex" ? 1 : 0,
@@ -138,7 +134,7 @@ const Left: React.FC<{
   }
 
   return (
-    <Flex pr={1} width={50}>
+    <Flex flex={1}>
       {leftElements ? (
         <>{leftElements}</>
       ) : (
@@ -147,8 +143,6 @@ const Left: React.FC<{
           <ArrowLeftIcon fill="onBackgroundHigh" top="2px" />
         </Touchable>
       )}
-
-      <Spacer x={1} />
     </Flex>
   )
 }

--- a/src/elements/Screen/Screen.stories.tsx
+++ b/src/elements/Screen/Screen.stories.tsx
@@ -26,6 +26,57 @@ storiesOf("Screen", module)
       </Screen.BottomView>
     </Screen>
   ))
+  .add("With Header and Right Element", () => (
+    <Screen>
+      <Screen.Header
+        title="Title"
+        rightElements={<Text variant="xs">Very long right element</Text>}
+      />
+      <Screen.Body scroll>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Text my={1} key={i}>
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+            dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+            mollit anim id est laborum."
+          </Text>
+        ))}
+      </Screen.Body>
+      <Screen.BottomView>
+        <Flex backgroundColor="black30" height={100} width="100%">
+          <Text>Footer</Text>
+        </Flex>
+      </Screen.BottomView>
+    </Screen>
+  ))
+  .add("With Custom Left Element", () => (
+    <Screen>
+      <Screen.Header
+        title="Title"
+        leftElements={<Text variant="xs">Very long left element</Text>}
+        rightElements={<Text variant="xs">right element</Text>}
+      />
+      <Screen.Body scroll>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Text my={1} key={i}>
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+            incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+            exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure
+            dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+            mollit anim id est laborum."
+          </Text>
+        ))}
+      </Screen.Body>
+      <Screen.BottomView>
+        <Flex backgroundColor="black30" height={100} width="100%">
+          <Text>Footer</Text>
+        </Flex>
+      </Screen.BottomView>
+    </Screen>
+  ))
   .add("ScrollView With AnimatedHeader", () => (
     <Screen>
       <Screen.AnimatedHeader title="Title" />


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Manage-saves-font-looks-broken-on-the-offer-page-update-font-size-according-to-design-and-center-bu-b344bd5a99f941fea5df5d4048679090?pvs=4

Related Eigen PR: https://github.com/artsy/eigen/pull/9928

Description
This pull request corrects the text alignment and centering in the screen header component.