### PR TITLE
fix: progressbar crash in dev and broken in prod

### DIFF
--- a/src/elements/ProgressBar/ProgressBar.tsx
+++ b/src/elements/ProgressBar/ProgressBar.tsx
@@ -24,16 +24,16 @@ export const ProgressBar = ({
   trackColor = "blue100",
 }: ProgressBarProps) => {
   const color = useColor()
-  const width = useSharedValue("0%")
+  const width = useSharedValue(0)
   const progress = clamp(unclampedProgress, 0, 100)
   const progressAnim = useAnimatedStyle(() => {
-    return { width: Number(width.value) }
+    return { width: `${width.value}%` }
   })
 
   const [onCompletionCalled, setOnCompletionCalled] = useState(false)
 
   useEffect(() => {
-    width.value = withTiming(`${progress}%`, { duration: animationDuration })
+    width.value = withTiming(progress, { duration: animationDuration })
 
     if (progress === 100 && !onCompletionCalled) {
       onCompletion?.()


### PR DESCRIPTION
This PR resolves [PHIRE-683] <!-- eg [PROJECT-XXXX] -->

### Description

Noticed that the progress bar is broken in prod in the onboarding, it was caused due to the rn bump in palette that we did a while ago ([diff here](https://github.com/artsy/palette-mobile/commit/fcf0b32fc8b5faa823da6819080a23d826bb438e#diff-f31c81aceb520986e64c9824ec29a0cbc561fea2fc707996cc1b4a0d4684acf6R30))

The TS error that I tried to fix on the diff above was because useAnimatedStyle expects a return type that is compatible with AnimatedStyleProp<ViewStyle | ImageStyle | TextStyle>. The width property in this case should be a number or a SharedValue<number> instead of a string.

Fixed this by converting the width value to a number before assigning it to the width property in the useAnimatedStyle hook.

This change assumes that the progress prop passed to the ProgressBar component is a number between 0 and 100. The width value is then calculated as a percentage of this progress as before.

### in eigen:

|Before|After|
|---|---|
|![Screenshot 2024-03-06 at 13 52 56](https://github.com/artsy/palette-mobile/assets/21178754/738e32d0-3eb7-4b38-9f79-27ad4d9ed419)|![Simulator Screenshot - iPhone 14 Pro - 2024-03-06 at 13 53 07](https://github.com/artsy/palette-mobile/assets/21178754/344d7d5e-0049-410e-b46c-c29871de2c81)|


### in palette: 
|Before|After|
|---|---|
|![Simulator Screenshot - iPhone 15 - 2024-03-06 at 13 54 46](https://github.com/artsy/palette-mobile/assets/21178754/31601a54-4f8e-4b56-bb02-c1bef05966ca)|![Simulator Screenshot - iPhone 15 - 2024-03-06 at 13 49 38](https://github.com/artsy/palette-mobile/assets/21178754/5e367ad4-25d9-443f-b45f-cc79f914897a)|




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[PHIRE-683]: https://artsyproduct.atlassian.net/browse/PHIRE-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ