### PR TITLE
feat: add onboarding state in pills

### DIFF
--- a/src/elements/Pill/Pill.stories.tsx
+++ b/src/elements/Pill/Pill.stories.tsx
@@ -106,5 +106,17 @@ storiesOf("Pill", module)
       </List>
     )
   })
+  .add("Onboarding", () => {
+    return (
+      <List contentContainerStyle={{ marginHorizontal: 20 }}>
+        <Pill variant="onboarding" selected>
+          Yes, I love collecting art
+        </Pill>
+        <Pill variant="onboarding" ml={1}>
+          No, I'm just starting out
+        </Pill>
+      </List>
+    )
+  })
 
 const src = "https://d32dm0rphc51dk.cloudfront.net/A983VUIZusVBKy420xP3ow/normalized.jpg"

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -16,6 +16,7 @@ export const PILL_VARIANT_NAMES = [
   "filter",
   "profile",
   "search",
+  "onboarding",
 ] as const
 export type PillState = "default" | "selected" | "disabled"
 export type PillVariant = typeof PILL_VARIANT_NAMES[number]
@@ -28,7 +29,10 @@ export type PillProps = (FlexProps & {
 }) &
   (
     | {
-        variant?: Extract<PillVariant, "default" | "filter" | "badge" | "search" | "dotted">
+        variant?: Extract<
+          PillVariant,
+          "default" | "filter" | "badge" | "search" | "dotted" | "onboarding"
+        >
         src?: never
       }
     | { variant: Extract<PillVariant, "profile">; src?: string }
@@ -126,6 +130,15 @@ const PILL_STATES = {
 
 const PILL_VARIANTS: Record<PillVariant, Record<PillState, FlattenInterpolation<any>>> = {
   default: PILL_STATES,
+  onboarding: {
+    ...PILL_STATES,
+    default: css`
+      ${PILL_STATES.default}
+      border-radius: 20px;
+      height: 40px;
+      border-color: ${themeGet("colors.black100")};
+    `,
+  },
   dotted: {
     ...PILL_STATES,
     default: css`
@@ -193,6 +206,7 @@ const defaultColors: Record<PillState, Color> = {
 }
 const TEXT_COLOR: Record<PillVariant, Record<PillState, Color>> = {
   default: defaultColors,
+  onboarding: defaultColors,
   dotted: {
     ...defaultColors,
     selected: "black100",

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -136,7 +136,7 @@ const PILL_VARIANTS: Record<PillVariant, Record<PillState, FlattenInterpolation<
       ${PILL_STATES.default}
       border-radius: 20px;
       height: 40px;
-      border-color: ${themeGet("colors.black100")};
+      border-color: ${themeGet("colors.black60")};
     `,
   },
   dotted: {


### PR DESCRIPTION
This PR resolves [PHIRE-118] <!-- eg [PROJECT-XXXX] -->

### Description

This is a part of a larger initiative for getting rid of the outdated `react-spring` library in eigen. For this reason we need this to get merged to be able to display the onboarding question pills correctly with this pill component that doesn't use react-spring.

#### Screenshots

from eigen: 

<img src="https://github.com/artsy/palette-mobile/assets/21178754/d29ece77-c023-48bd-ab1b-0fd02b7984ad" width="300" />

from stories (in palette-mobile):
<img src="https://github.com/artsy/palette-mobile/assets/21178754/d166818b-d75f-48cf-bffd-72720b85707b" width="300" />



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[PHIRE-118]: https://artsyproduct.atlassian.net/browse/PHIRE-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ