### PR TITLE
fix(radio): fix alignment between button and text

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -46,6 +46,7 @@ const getStories = () => {
     require("../src/elements/Pill/Pill.stories.tsx"),
     require("../src/elements/Popover/Popover.stories.tsx"),
     require("../src/elements/ProgressBar/ProgressBar.stories.tsx"),
+    require("../src/elements/Radio/RadioButton.stories.tsx"),
     require("../src/elements/Screen/Screen.stories.tsx"),
     require("../src/elements/Separator/Separator.stories.tsx"),
     require("../src/elements/Skeleton/Skeleton.stories.tsx"),

--- a/src/elements/Radio/RadioButton.stories.tsx
+++ b/src/elements/Radio/RadioButton.stories.tsx
@@ -1,0 +1,42 @@
+import { storiesOf } from "@storybook/react-native"
+import { useState } from "react"
+import { RadioButton } from "./RadioButton"
+import { List } from "../../storybook/helpers"
+import { Flex } from "../Flex"
+
+export default {
+  title: "RadioButton",
+  component: RadioButton,
+}
+
+storiesOf("RadioButton", module).add("Default", () => {
+  const [metric, setMetric] = useState("cm")
+
+  return (
+    <List
+      contentContainerStyle={{
+        marginHorizontal: 20,
+        justifyContent: "flex-start",
+        alignItems: "flex-start",
+      }}
+    >
+      <Flex flexDirection="row" gap={20}>
+        <RadioButton
+          onPress={() => {
+            setMetric("cm")
+          }}
+          selected={metric === "cm"}
+          text="centimeters"
+        />
+
+        <RadioButton
+          onPress={() => {
+            setMetric("in")
+          }}
+          selected={metric === "in"}
+          text="inches"
+        />
+      </Flex>
+    </List>
+  )
+})

--- a/src/elements/Radio/RadioButton.tsx
+++ b/src/elements/Radio/RadioButton.tsx
@@ -34,10 +34,8 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
   disabled,
   error,
   onPress,
-  style,
   text,
   subtitle,
-  children,
   accessibilityState,
   ...restProps
 }) => {

--- a/src/elements/Radio/RadioButton.tsx
+++ b/src/elements/Radio/RadioButton.tsx
@@ -89,7 +89,7 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
       }}
     >
       <Flex {...restProps}>
-        <Flex flexDirection="row">
+        <Flex flexDirection="row" alignItems="center">
           <Flex mt="2px">
             <CssTransition
               style={[


### PR DESCRIPTION
This PR resolves [ONYX-819] <!-- eg [PROJECT-XXXX] -->

### Description

Radio buttons in palette-mobile currently suffer from poor alignment between button and text. 

Example from SwA flow in Eigen:

<img width=400 src="https://github.com/artsy/palette-mobile/assets/140521/2afbafc1-a744-499c-9ca2-a6183b86e4ca" />

It seems to me that people have worked around this problem in Eigen by building up custom flex layouts that include:

- a `<RadioButton />` _without_ the `text` prop
- combined with a custom `<Text />` element
- all of the above wrapped in a `<Touchable />`

(Examples [here](https://github.com/artsy/eigen/blob/7423ddbfa513f79a638193434a118bdc13261d95/src/app/Scenes/Artwork/Components/ArtworkEditionSetItem.tsx#L41-L64) and [here](https://github.com/artsy/eigen/blob/7423ddbfa513f79a638193434a118bdc13261d95/src/app/system/devTools/DevMenu/CodePushOptions.tsx#L81-L89) and [here](https://github.com/artsy/eigen/blob/7423ddbfa513f79a638193434a118bdc13261d95/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize.tsx#L99-L114))

I think it would be better to fix this at the root, here in palette-mobile, so that these^ contortions are not necessary and the `RadioButton` can simply be used as-is, with the `text` prop.

That's what this PR does:

|Before|After|
|---|---|
|![before](https://github.com/artsy/palette-mobile/assets/140521/ca84ccb8-e293-451c-886f-c81cbc57d97e)|![after](https://github.com/artsy/palette-mobile/assets/140521/85d7dd96-6fe6-430d-a3f7-5a6dd3e5b2da)|

There are only a handful of cases in Eigen and Energy where the component is used as-is. Those will just inherit the improved alignment once they upgrade to this version of palette-mobile.

The more custom layouts I cited above should not be affected — though it might be nice to simplify those components and use the improved behavior now.

[ONYX-819]: https://artsyproduct.atlassian.net/browse/ONYX-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ