### PR TITLE
feat: Add `preventUnmount` prop to `CollapsibleMenuItem`

### DIFF
--- a/src/elements/Collapse/Collapse.tsx
+++ b/src/elements/Collapse/Collapse.tsx
@@ -5,7 +5,7 @@ interface CollapseProps {
   opened: boolean
   children: ReactNode
   /**
-   * Prevents the component from unmounting when it is closed  (display: none)
+   * Prevent the content from being unmounted when it is collapsed (display: none)
    */
   preventUnmount?: boolean
 }

--- a/src/elements/Collapse/Collapse.tsx
+++ b/src/elements/Collapse/Collapse.tsx
@@ -1,5 +1,17 @@
 import { ReactNode } from "react"
 import { View } from "react-native"
 
-export const Collapse = ({ opened, children }: { opened: boolean; children: ReactNode }) =>
-  opened ? <View>{children}</View> : null
+interface CollapseProps {
+  opened: boolean
+  children: ReactNode
+  /**
+   * Prevents the component from unmounting when it is closed  (display: none)
+   */
+  preventUnmount?: boolean
+}
+
+export const Collapse: React.FC<CollapseProps> = ({ opened, children, preventUnmount = false }) => {
+  if (preventUnmount) return <View style={{ display: opened ? null : "none" }}>{children}</View>
+
+  return opened ? <View>{children}</View> : null
+}

--- a/src/elements/Collapse/Collapse.tsx
+++ b/src/elements/Collapse/Collapse.tsx
@@ -4,15 +4,8 @@ import { View } from "react-native"
 interface CollapseProps {
   opened: boolean
   children: ReactNode
-  /**
-   * Prevent the content from being unmounted when it is collapsed (display: none)
-   */
-  preventUnmount?: boolean
 }
 
-export const Collapse: React.FC<CollapseProps> = ({ opened, children, preventUnmount = false }) => {
-  if (preventUnmount)
-    return <View style={{ display: opened ? undefined : "none" }}>{children}</View>
-
-  return opened ? <View>{children}</View> : null
+export const Collapse: React.FC<CollapseProps> = ({ opened, children }) => {
+  return <View style={{ display: opened ? undefined : "none" }}>{children}</View>
 }

--- a/src/elements/Collapse/Collapse.tsx
+++ b/src/elements/Collapse/Collapse.tsx
@@ -11,7 +11,8 @@ interface CollapseProps {
 }
 
 export const Collapse: React.FC<CollapseProps> = ({ opened, children, preventUnmount = false }) => {
-  if (preventUnmount) return <View style={{ display: opened ? null : "none" }}>{children}</View>
+  if (preventUnmount)
+    return <View style={{ display: opened ? undefined : "none" }}>{children}</View>
 
   return opened ? <View>{children}</View> : null
 }

--- a/src/elements/CollapsibleMenuItem/CollapsibleMenuItem.tsx
+++ b/src/elements/CollapsibleMenuItem/CollapsibleMenuItem.tsx
@@ -11,6 +11,10 @@ interface CollapsableMenuItemProps {
   title: string
   isExpanded?: boolean
   disabled?: boolean
+  /**
+   * Prevents the component from unmounting when it is closed  (display: none)
+   */
+  preventUnmount?: boolean
   onExpand?: () => void
   onCollapse?: () => void
 }
@@ -28,7 +32,16 @@ export const CollapsibleMenuItem = forwardRef<
   React.PropsWithChildren<CollapsableMenuItemProps>
 >(
   (
-    { children, overtitle, title, isExpanded = false, disabled = false, onExpand, onCollapse },
+    {
+      children,
+      overtitle,
+      title,
+      isExpanded = false,
+      disabled = false,
+      preventUnmount,
+      onExpand,
+      onCollapse,
+    },
     ref
   ) => {
     const [isOpen, setIsOpen] = useState(false)
@@ -105,7 +118,9 @@ export const CollapsibleMenuItem = forwardRef<
             </Flex>
           </Flex>
         </Touchable>
-        <Collapse opened={isOpen}>{children}</Collapse>
+        <Collapse opened={isOpen} preventUnmount={preventUnmount}>
+          {children}
+        </Collapse>
       </Flex>
     )
   }

--- a/src/elements/CollapsibleMenuItem/CollapsibleMenuItem.tsx
+++ b/src/elements/CollapsibleMenuItem/CollapsibleMenuItem.tsx
@@ -11,10 +11,6 @@ interface CollapsableMenuItemProps {
   title: string
   isExpanded?: boolean
   disabled?: boolean
-  /**
-   * Prevents the component from unmounting when it is closed  (display: none)
-   */
-  preventUnmount?: boolean
   onExpand?: () => void
   onCollapse?: () => void
 }
@@ -32,16 +28,7 @@ export const CollapsibleMenuItem = forwardRef<
   React.PropsWithChildren<CollapsableMenuItemProps>
 >(
   (
-    {
-      children,
-      overtitle,
-      title,
-      isExpanded = false,
-      disabled = false,
-      preventUnmount,
-      onExpand,
-      onCollapse,
-    },
+    { children, overtitle, title, isExpanded = false, disabled = false, onExpand, onCollapse },
     ref
   ) => {
     const [isOpen, setIsOpen] = useState(false)
@@ -118,9 +105,7 @@ export const CollapsibleMenuItem = forwardRef<
             </Flex>
           </Flex>
         </Touchable>
-        <Collapse opened={isOpen} preventUnmount={preventUnmount}>
-          {children}
-        </Collapse>
+        <Collapse opened={isOpen}>{children}</Collapse>
       </Flex>
     )
   }


### PR DESCRIPTION
This PR resolves [ONYX-815] <!-- eg [PROJECT-XXXX] -->

- Related Eigen PR: https://github.com/artsy/eigen/pull/9998

### Description

This PR adds a `preventUnmount` prop to `CollapsibleMenuItem` that prevents unmounting the content when collapsed. This change is needed in order to not lose the current state when a step in the SWA form is collapsed.

## Screenshots

![Simulator Screenshot - iPhone 15 Pro - 2024-03-25 at 16 45 43](https://github.com/artsy/palette-mobile/assets/4691889/d08c9393-abad-407f-87bb-4b94d3da9ffd)


[ONYX-815]: https://artsyproduct.atlassian.net/browse/ONYX-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ