### PR TITLE
fix: add zIndex to the ToolTip component

### DIFF
--- a/src/elements/ToolTip/ToolTipFlyout.tsx
+++ b/src/elements/ToolTip/ToolTipFlyout.tsx
@@ -74,6 +74,7 @@ export const ToolTipFlyout: React.FC<Props> = ({
             backgroundColor: color("black100"),
             position: "absolute",
             alignSelf: "center",
+            zIndex: 1,
           },
           containerStyle,
           animationStyle,


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR fixes the ToolTip component.
In some implementations the content under the ToolTip is visible - we should avoid that.
Fixed by adding zIndex to the ToolTipFlyout 

| Before | After |
| --- | --- |
| ![image](https://github.com/artsy/palette-mobile/assets/36167539/2763f4b3-49d6-46b7-ab0b-d59984e53d9a) | ![image](https://github.com/artsy/palette-mobile/assets/36167539/a968bb2e-c1d6-46ce-a346-095919a70841) |