### PR TITLE
fix(APPL-872): return null if Collapse is not opened

### DIFF
--- a/src/elements/Collapse/Collapse.tsx
+++ b/src/elements/Collapse/Collapse.tsx
@@ -7,5 +7,9 @@ export interface CollapseProps {
 }
 
 export const Collapse: React.FC<CollapseProps> = ({ opened, children }) => {
-  return <View style={{ display: opened ? undefined : "none" }}>{children}</View>
+  if (!opened) {
+    return null
+  }
+
+  return <View>{children}</View>
 }


### PR DESCRIPTION
This PR resolves [APPL-872] <!-- eg [PROJECT-XXXX] -->

### Description
This PR updates the Collapse element to not render a view when the Collapse is not opened

cc @artsy/onyx-devs 
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[APPL-872]: https://artsyproduct.atlassian.net/browse/APPL-872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ