### PR TITLE
build(deps): bump auto deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   },
   "devDependencies": {
     "@artsy/auto-config": "1.2.0",
-    "@auto-it/all-contributors": "10.38.5",
-    "@auto-it/first-time-contributor": "10.38.5",
+    "@auto-it/all-contributors": "10.46.0",
+    "@auto-it/first-time-contributor": "10.46.0",
     "@babel/core": "^7.20.12",
     "@babel/plugin-proposal-decorators": "7.20.13",
     "@babel/preset-env": "^7.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,13 +28,13 @@
   resolved "https://registry.yarnpkg.com/@artsy/palette-tokens/-/palette-tokens-5.0.0.tgz#d1e1917d8163d88e7a9f877cf06b609fa8c8178c"
   integrity sha512-nloC0ubH5XDVNiplehwTtDLEgY0vjeE3l8QUYppEIHFCgadntXm6aVlmEC79inO7L3lDYN7JckYlIYRrTJg3vw==
 
-"@auto-it/all-contributors@10.38.5":
-  version "10.38.5"
-  resolved "https://registry.yarnpkg.com/@auto-it/all-contributors/-/all-contributors-10.38.5.tgz#8606ea49cfa8a036e75a2bd0a914fac43a8303e5"
-  integrity sha512-JC+QdMGM6WJonfKRW9Y0SKBI7ittrrbxwIzw7kOVZ7F1OdzvcLu61xrcpUlQIuhLte8xKFnSdSq3LFZvM1UCAA==
+"@auto-it/all-contributors@10.46.0":
+  version "10.46.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/all-contributors/-/all-contributors-10.46.0.tgz#adb80be82116f39656674282d058210fc656c8c7"
+  integrity sha512-VxLWXB+mRkXTQBO4YsbFJIKhAry4O28sYlbDQWCZwWBz2Ku9r2R26FrQ79LwBNqAjD/BiugcikVgItP6yoz+5A==
   dependencies:
-    "@auto-it/bot-list" "10.38.5"
-    "@auto-it/core" "10.38.5"
+    "@auto-it/bot-list" "10.46.0"
+    "@auto-it/core" "10.46.0"
     "@octokit/rest" "^18.12.0"
     all-contributors-cli "6.19.0"
     anymatch "^3.1.1"
@@ -50,6 +50,11 @@
   version "10.38.5"
   resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-10.38.5.tgz#51453cd9dfe455e0dfefdfc004756749a84d5575"
   integrity sha512-Svi7SyMpXjvPmsRXEW/sU4SoI+gpvZW3KeHBdRHXE+kGd4TIvGwX8Sg0ojT8OsaiFk+8xSodv9ajf8MMI6jqPA==
+
+"@auto-it/bot-list@10.46.0":
+  version "10.46.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-10.46.0.tgz#8e8c3d3bb68b8b4e13705fff373fbdab14869249"
+  integrity sha512-QkkBgQVi1g/1Tpxcs3Hm3zTzaaM0xjiIRt5xEA6TRM/ULdgEqY+Jk/w1fJZe9GVF+53mwRfqGtQeJirilMBH6g==
 
 "@auto-it/core@10.38.5":
   version "10.38.5"
@@ -97,13 +102,59 @@
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
-"@auto-it/first-time-contributor@10.38.5":
-  version "10.38.5"
-  resolved "https://registry.yarnpkg.com/@auto-it/first-time-contributor/-/first-time-contributor-10.38.5.tgz#6fc064eacee2aa2b3d257223dd39191e93ff776c"
-  integrity sha512-gO5aMulO8jS6aUHa8blEscAvVwXv5lx+zc++tf9W8MtTfUj0ZMzWPNhV/MTkgEgQzT0PJDoJNB9jZvC4B0U71g==
+"@auto-it/core@10.46.0":
+  version "10.46.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-10.46.0.tgz#f7445ab03478cd9819e6bb78b1e5a441240dbf5f"
+  integrity sha512-68jWcUuQBFCjgUvEWa64ENeRPULFYiaFpo37H6SUuLcZ2XBD+Bt4Y0yqHWjs6F5g19S7pzOYe25SxWf+U0J4LQ==
   dependencies:
-    "@auto-it/bot-list" "10.38.5"
-    "@auto-it/core" "10.38.5"
+    "@auto-it/bot-list" "10.46.0"
+    "@endemolshinegroup/cosmiconfig-typescript-loader" "^3.0.2"
+    "@octokit/core" "^3.5.1"
+    "@octokit/plugin-enterprise-compatibility" "1.3.0"
+    "@octokit/plugin-retry" "^3.0.9"
+    "@octokit/plugin-throttling" "^3.6.2"
+    "@octokit/rest" "^18.12.0"
+    await-to-js "^3.0.0"
+    chalk "^4.0.0"
+    cosmiconfig "7.0.0"
+    deepmerge "^4.0.0"
+    dotenv "^8.0.0"
+    endent "^2.1.0"
+    enquirer "^2.3.4"
+    env-ci "^5.0.1"
+    fast-glob "^3.1.1"
+    fp-ts "^2.5.3"
+    fromentries "^1.2.0"
+    gitlog "^4.0.3"
+    https-proxy-agent "^5.0.0"
+    import-cwd "^3.0.0"
+    import-from "^3.0.0"
+    io-ts "^2.1.2"
+    lodash.chunk "^4.2.0"
+    log-symbols "^4.0.0"
+    node-fetch "2.6.7"
+    parse-author "^2.0.0"
+    parse-github-url "1.0.2"
+    pretty-ms "^7.0.0"
+    requireg "^0.2.2"
+    semver "^7.0.0"
+    signale "^1.4.0"
+    tapable "^2.2.0"
+    terminal-link "^2.1.1"
+    tinycolor2 "^1.4.1"
+    ts-node "^10.9.1"
+    tslib "2.1.0"
+    type-fest "^0.21.1"
+    typescript-memoize "^1.0.0-alpha.3"
+    url-join "^4.0.0"
+
+"@auto-it/first-time-contributor@10.46.0":
+  version "10.46.0"
+  resolved "https://registry.yarnpkg.com/@auto-it/first-time-contributor/-/first-time-contributor-10.46.0.tgz#c5fa9317c01520d457b31982cae96ef994a31678"
+  integrity sha512-P/taTwvrFSOtCu1FOTzVx7iSMBSFroW5NZEZ6oLttEWoGsiGI9VYBY7yGIh47g7dreS1Y+xA1iTfUMCHIcyrmg==
+  dependencies:
+    "@auto-it/bot-list" "10.46.0"
+    "@auto-it/core" "10.46.0"
     array.prototype.flatmap "^1.2.2"
     endent "^2.1.0"
     tslib "2.1.0"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Tried to rerun the jobs on main without any luck so proceeding with the following:

Attempting to fix the broken CI pipeline by bumping auto deps, error can be found [here](https://app.circleci.com/pipelines/github/artsy/palette-mobile/707/workflows/ad5c1a97-397b-4576-904f-e84278696495/jobs/1855)

Preview of the error:

```bash
Error: Running command 'git' with args [add, .all-contributorsrc] failed

fatal: pathspec '.all-contributorsrc' did not match any files

    at ChildProcess.<anonymous> (/snapshot/auto/node_modules/@auto-it/core/src/utils/exec-promise.ts:76:23)
    at ChildProcess.emit (events.js:315:20)
    at ChildProcess.EventEmitter.emit (domain.js:482:12)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)Error: 
    at Object.execPromise (/snapshot/auto/node_modules/@auto-it/core/src/utils/exec-promise.ts:17:20)
    at /snapshot/auto/plugins/all-contributors/dist/index.js:234:30
    at processTicksAndRejections (internal/process/task_queues.js:97:5)

Exited with code exit status 1
```

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
