### PR TITLE
build(package.json): fixes package json repo property

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,10 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "artsy/palette-mobile",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/artsy/palette-mobile.git"
+  },
   "author": "Pavlos Vinieratos <pvinis@gmail.com>",
   "license": "MIT",
   "lint-staged": {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

By checking the history of publish jobs noticed a warning that we need to change the `repository` in package json like this to be able to publish.

Usually it was doing the change on the ci and never committing but I committed the change here.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.1.31--canary.220.1879.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@13.1.31--canary.220.1879.0
  # or 
  yarn add @artsy/palette-mobile@13.1.31--canary.220.1879.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
