### PR TITLE
chore: add support to children in message component

### DIFF
--- a/src/elements/Message/Message.stories.tsx
+++ b/src/elements/Message/Message.stories.tsx
@@ -1,4 +1,5 @@
 import { storiesOf } from "@storybook/react-native"
+import { Text } from "react-native"
 import { Message } from "./Message"
 import { withTheme } from "../../storybook/decorators"
 import { List } from "../../storybook/helpers"
@@ -8,6 +9,9 @@ storiesOf("Message", module)
   .add("Variants", () => (
     <List contentContainerStyle={{ marginHorizontal: 20, alignItems: "stretch" }}>
       <Message variant="default" title="Without Close Button" text="Text" />
+      <Message variant="default" title="Without Close Button">
+        <Text>Text</Text>
+      </Message>
       <Message variant="default" showCloseButton title="Title" text="Text" />
       <Message
         variant="default"

--- a/src/elements/Message/Message.tsx
+++ b/src/elements/Message/Message.tsx
@@ -24,6 +24,7 @@ export interface MessageProps {
 
 export const Message: React.FC<MessageProps> = ({
   bodyTextStyle,
+  children,
   containerStyle,
   IconComponent,
   iconPosition = "left",
@@ -87,6 +88,7 @@ export const Message: React.FC<MessageProps> = ({
                 {text}
               </Text>
             )}
+            {children}
           </Flex>
 
           {!!IconComponent && iconPosition === "right" && (


### PR DESCRIPTION
This PR resolves https://github.com/artsy/eigen/pull/10175#discussion_r1601498539

### Description
Add support to `children` in Message Component

<img width="373" alt="Screenshot 2024-05-15 at 16 01 03" src="https://github.com/artsy/palette-mobile/assets/11945712/cecba535-f046-4dfd-8cf9-617fd367668f">
