### PR TITLE
chore: update commit author to shared account #trivial

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -3,5 +3,9 @@
     "npm",
     "first-time-contributor",
     "released"
-  ]
+  ],
+  "author": {
+    "name": "Artsy",
+    "email": "it@artsymail.com"
+  }
 }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,12 @@ workflows:
           requires:
             - test
             - type-check
+          pre-steps:
+            - run:
+                name: Show Git Config
+                command: |
+                  echo "Git User Name: $(git config user.name)"
+                  echo "Git User Email: $(git config user.email)"
 
       - auto/publish:
           context: npm-deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,12 +86,6 @@ workflows:
           requires:
             - test
             - type-check
-          pre-steps:
-            - run:
-                name: Show Git Config
-                command: |
-                  echo "Git User Name: $(git config user.name)"
-                  echo "Git User Email: $(git config user.email)"
 
       - auto/publish:
           context: npm-deploy


### PR DESCRIPTION
This PR resolves [PHIRE-847] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Attempt to change auto commits to use artsy shared account. 

Auto according to docs picks up author from package.json: https://intuit.github.io/auto/docs/generated/shipit#examples

I think setting this in the autorc should work but if not we can try to pass explicitly in our auto commands or change the package.json. 

[PHIRE-847]: https://artsyproduct.atlassian.net/browse/PHIRE-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ