### PR TITLE
fix: loading state to FollowButton, hides checkmark when loading

### DIFF
--- a/src/elements/Button/FollowButton.tsx
+++ b/src/elements/Button/FollowButton.tsx
@@ -16,6 +16,7 @@ export const FollowButton = ({
   isFollowed,
   followCount,
   longestText,
+  loading,
   ...restProps
 }: FollowButtonProps) => {
   return (
@@ -23,15 +24,20 @@ export const FollowButton = ({
       variant={isFollowed ? "outline" : "outlineGray"}
       size="small"
       longestText={longestText ? longestText : "Following"}
-      icon={isFollowed && <CheckIcon fill="black60" width="16px" height="16px" />}
+      icon={isFollowed && !loading && <CheckIcon fill="black60" width="16px" height="16px" />}
+      loading={loading}
       {...restProps}
     >
-      <Text variant="xs">{isFollowed ? "Following" : "Follow"}</Text>
-      {!!followCount && followCount > 1 && (
+      {!loading && (
         <>
-          <Text variant="xs" color="black60">
-            {" " + formatLargeNumber(followCount, 1)}
-          </Text>
+          <Text variant="xs">{isFollowed ? "Following" : "Follow"}</Text>
+          {!!followCount && followCount > 1 && (
+            <>
+              <Text variant="xs" color="black60">
+                {" " + formatLargeNumber(followCount, 1)}
+              </Text>
+            </>
+          )}
         </>
       )}
     </Button>

--- a/src/elements/ButtonNew/FollowButton.tsx
+++ b/src/elements/ButtonNew/FollowButton.tsx
@@ -16,6 +16,7 @@ export const FollowButton = ({
   isFollowed,
   followCount,
   longestText,
+  loading,
   ...restProps
 }: FollowButtonProps) => {
   return (
@@ -23,15 +24,20 @@ export const FollowButton = ({
       variant={isFollowed ? "outline" : "outlineGray"}
       size="small"
       longestText={longestText ? longestText : "Following"}
-      icon={isFollowed && <CheckIcon fill="black60" width="16px" height="16px" />}
+      icon={isFollowed && !loading && <CheckIcon fill="black60" width="16px" height="16px" />}
+      loading={loading}
       {...restProps}
     >
-      <Text variant="xs">{isFollowed ? "Following" : "Follow"}</Text>
-      {!!followCount && followCount > 1 && (
+      {!loading && (
         <>
-          <Text variant="xs" color="black60">
-            {" " + formatLargeNumber(followCount, 1)}
-          </Text>
+          <Text variant="xs">{isFollowed ? "Following" : "Follow"}</Text>
+          {!!followCount && followCount > 1 && (
+            <>
+              <Text variant="xs" color="black60">
+                {" " + formatLargeNumber(followCount, 1)}
+              </Text>
+            </>
+          )}
         </>
       )}
     </Button>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR resolves [this bug](https://www.notion.so/artsy/Follow-button-in-gallery-list-in-Onboarding-flow-is-broken-f0979e9ec5ba477193b3dd602493f4da?pvs=4) with the follow button that came out of the Sprintly Mobile QA session

- [x] Hides checkmark when follow button is loading
- [x] Hides text when follow button is loading - (loader is shown from followButton button component)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
