### PR TITLE
build(deps): bump @shopify/flash-list from 1.5.0 to 1.6.4

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -516,7 +516,7 @@ PODS:
     - React-Core
     - SDWebImage (~> 5.11.1)
     - SDWebImageWebPCoder (~> 0.8.4)
-  - RNFlashList (1.5.0):
+  - RNFlashList (1.6.4):
     - React-Core
   - RNReactNativeHapticFeedback (1.14.0):
     - React-Core
@@ -823,7 +823,7 @@ SPEC CHECKSUMS:
   RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
   RNDeviceInfo: 4701f0bf2a06b34654745053db0ce4cb0c53ada7
   RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
-  RNFlashList: 25b0e092b4470c84db0386d4f5316dc34123bb6d
+  RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
   RNReactNativeHapticFeedback: 1e3efeca9628ff9876ee7cdd9edec1b336913f8c
   RNReanimated: 9f7068e43b9358a46a688d94a5a3adb258139457
   RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "dependencies": {
     "@artsy/palette-tokens": "^5.0.0",
-    "@shopify/flash-list": "^1.5.0",
+    "@shopify/flash-list": "^1.6.4",
     "@styled-system/core": "^5.1.2",
     "@styled-system/theme-get": "^5.1.2",
     "events": "^3.3.0",
@@ -55,12 +55,12 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
+    "react-native-blurhash": "^1.1.11",
     "react-native-haptic-feedback": "*",
     "react-native-linear-gradient": "*",
     "react-native-reanimated": "*",
     "react-native-svg": "*",
-    "styled-components": ">= 5",
-    "react-native-blurhash": "^1.1.11"
+    "styled-components": ">= 5"
   },
   "devDependencies": {
     "@artsy/auto-config": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3224,10 +3224,10 @@
     invariant "^2.2.4"
     nullthrows "^1.1.1"
 
-"@shopify/flash-list@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@shopify/flash-list/-/flash-list-1.5.0.tgz#f1cf3c4f9bb706a58c3d1f794ddfaedb5872f431"
-  integrity sha512-XeocevDIXastr6jh3TPo1MzV5XkdqTyWtw/j8kUhz9EOBc2SzNWbpJWyzrAsYKlqYNrnxxs0P9C0amlX2jaQnw==
+"@shopify/flash-list@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@shopify/flash-list/-/flash-list-1.6.4.tgz#2844ae7334f314c06c62b649bc9c5de2480800b4"
+  integrity sha512-M2momcnY7swsvmpHIFDVbdOaFw4aQocJXA/lFP0Gpz+alQjFylqVKvszxl4atYO2SNbjxlb2L6hEP9WEcAknGQ==
   dependencies:
     recyclerlistview "4.2.0"
     tslib "2.4.0"


### PR DESCRIPTION
This PR resolves [PHIRE-957] <!-- eg [PROJECT-XXXX] -->

### Description

Bumps flashlist dependency

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
