### PR TITLE
chore: allow disabling keyboard avoidance

### DIFF
--- a/src/elements/Screen/Body.tsx
+++ b/src/elements/Screen/Body.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react"
 import { KeyboardAvoidingView, Platform, ScrollView } from "react-native"
 import { SCREEN_HORIZONTAL_PADDING } from "./constants"
 import { Flex, FlexProps } from "../Flex"
@@ -5,19 +6,25 @@ import { Flex, FlexProps } from "../Flex"
 export interface BodyProps extends FlexProps {
   fullwidth?: boolean
   scroll?: boolean
+  disableKeyboardAvoidance?: boolean
 }
 
-export const Body: React.FC<BodyProps> = ({ children, fullwidth, scroll, ...flexProps }) => {
+export const Body: React.FC<BodyProps> = ({
+  children,
+  fullwidth,
+  scroll,
+  disableKeyboardAvoidance = false,
+  ...flexProps
+}) => {
+  const Wrapper = disableKeyboardAvoidance ? Fragment : KeyboardAvoidingView
+
   return (
-    <KeyboardAvoidingView
-      style={{ flex: 1 }}
-      behavior={Platform.OS === "ios" ? "padding" : "height"}
-    >
+    <Wrapper style={{ flex: 1 }} behavior={Platform.OS === "ios" ? "padding" : "height"}>
       <Flex flex={1} {...flexProps}>
         <Flex flex={1} px={fullwidth ? undefined : SCREEN_HORIZONTAL_PADDING}>
           {scroll ? <ScrollView>{children}</ScrollView> : children}
         </Flex>
       </Flex>
-    </KeyboardAvoidingView>
+    </Wrapper>
   )
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds support to disabling keyboard avoidance to `Screen.Body`

**Why am I adding this?**
When the user dismisses a screen where they had the keyboard visible, the `KeyboardAvoidingView` takes action of adjusting the screen content in order to fit it within the screen. Most of the cases, this will result in nothing, since there is nothing to push up, however in the case where we have a sticky button (like the case of SWA landing page "Start Selling" button), we will see that button going down along with the keyboard. Which is something you wouldn't expect since the screen wasn't active.



https://github.com/artsy/palette-mobile/assets/11945712/15372521-dd88-4bc5-8ea0-dd0fb9bec8fb



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
