### PR TITLE
chore: add iconsize prop

### DIFF
--- a/src/elements/BackButton/BackButton.tsx
+++ b/src/elements/BackButton/BackButton.tsx
@@ -10,6 +10,7 @@ export interface BackButtonProps {
   onPress?: () => void
   showX?: boolean
   style?: TouchableOpacityProps["style"]
+  iconSize?: number
 }
 
 export const BackButton: React.FC<BackButtonProps> = ({
@@ -18,6 +19,7 @@ export const BackButton: React.FC<BackButtonProps> = ({
   onPress,
   showX = false,
   style,
+  iconSize = 18,
 }) => {
   return (
     <TouchableOpacity
@@ -29,9 +31,9 @@ export const BackButton: React.FC<BackButtonProps> = ({
       style={style}
     >
       {showX ? (
-        <CloseIcon fill={color} width={26} height={26} />
+        <CloseIcon fill={color} width={iconSize} height={iconSize} />
       ) : (
-        <ChevronIcon direction="left" fill={color} />
+        <ChevronIcon direction="left" fill={color} height={iconSize} width={iconSize} />
       )}
     </TouchableOpacity>
   )


### PR DESCRIPTION
### Description

This PR comes as a follow-up on the new SWA flow. The goal here is to support smaller sizes for icons

I am adjusting the size to 18 here and also adding an `iconSize` prop to be able to update it. Luckily, `showX` wasn't used anywhere that's not new

 
<img width="652" alt="Screenshot 2024-06-05 at 17 51 38" src="https://github.com/artsy/palette-mobile/assets/11945712/1c182b10-2e44-4aa9-b5fa-29534ec73ed0">

See: https://www.figma.com/design/E6rVm1tiSI4PW3EzibKKZw/Submission-%26-Pre-Consignment-Management?node-id=1061-27259&t=nsaHoKkIDtqvcK0d-0

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
