### PR TITLE
chore: support progressBarStyle for ProgressBar component

### DIFF
--- a/src/elements/ProgressBar/ProgressBar.tsx
+++ b/src/elements/ProgressBar/ProgressBar.tsx
@@ -14,6 +14,7 @@ export interface ProgressBarProps {
   progress: number
   trackColor?: Color
   style?: ViewStyle
+  progressBarStyle?: ViewStyle
 }
 
 const clamp = (num: number, min: number, max: number) => Math.max(min, Math.min(num, max))
@@ -26,6 +27,7 @@ export const ProgressBar = ({
   progress: unclampedProgress,
   trackColor = "blue100",
   style,
+  progressBarStyle,
 }: ProgressBarProps) => {
   const color = useColor()
   const space = useSpace()
@@ -58,7 +60,7 @@ export const ProgressBar = ({
     >
       <Animated.View
         testID="progress-bar-track"
-        style={[progressAnim, { height, backgroundColor: color(trackColor) }]}
+        style={[progressAnim, { height, backgroundColor: color(trackColor) }, progressBarStyle]}
       />
     </Flex>
   )


### PR DESCRIPTION
### Description

This PR adds support of injecting styles into the progress bar component. Although ideally we should not inject any styles here, Design wants to be able adjust a few properties of the progress bar when it's not full screen. In the most recent case, making it round


![simulator_screenshot_9A4082D6-62AD-4E75-9BE7-327DD2E2ED49](https://github.com/artsy/palette-mobile/assets/11945712/b10a3f32-bb85-4a28-ac09-abf8a945473a)


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
