### PR TITLE
chore: support text variants for radio button

### DIFF
--- a/src/elements/Radio/RadioButton.tsx
+++ b/src/elements/Radio/RadioButton.tsx
@@ -1,3 +1,4 @@
+import { TextVariant } from "@artsy/palette-tokens/dist/typography/v3"
 import { themeGet } from "@styled-system/theme-get"
 import {
   Insets,
@@ -25,6 +26,7 @@ export interface RadioButtonProps
   disabled?: boolean
   error?: boolean
   text?: React.ReactElement | string
+  textVariant?: TextVariant
   subtitle?: React.ReactElement | string
   accessibilityState?: { checked: boolean }
 }
@@ -35,6 +37,7 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
   error,
   onPress,
   text,
+  textVariant = "md",
   subtitle,
   accessibilityState,
   ...restProps
@@ -111,7 +114,7 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 
           <Flex justifyContent="center">
             {!!text && (
-              <Text variant="md" color={textColor}>
+              <Text variant={textVariant} color={textColor}>
                 {text}
               </Text>
             )}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR comes to support text variants on radio buttons. this is in order to match palette https://www.figma.com/design/gZNkyqLT8AU3T61tluVJyB/Artsy-3.1-Design-System?node-id=6726-3939&m=dev



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
