### PR TITLE
fix: checkbox subtitle text color

### DIFF
--- a/src/elements/Checkbox/Checkbox.tsx
+++ b/src/elements/Checkbox/Checkbox.tsx
@@ -81,7 +81,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
     : checkboxStyles[error ? "error" : "default"][isChecked ? "checked" : "unchecked"]
 
   const textColor = error ? color("red100") : disabled ? color("black30") : color("black100")
-  const subtitleColor = error ? color("red100") : color("black30")
+  const subtitleColor = error ? color("red100") : disabled ? color("black30") : color("black60")
 
   return (
     <TouchableWithoutFeedback


### PR DESCRIPTION
### Description

This PR fixes an issue with the styling of the subtitle text. It's currently `black30` but needs to be `black60`. 


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
