### PR TITLE
feat: support masks

### DIFF
--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -42,7 +42,7 @@ export const emitInputClearEvent = () => {
   inputEvents.emit("clear")
 }
 
-export interface InputProps extends Omit<TextInputProps, "placeholder"> {
+export interface InputProps extends Omit<TextInputProps, "placeholder" | "onChangeText"> {
   addClearListener?: boolean
   /**
    * We are applying some optimisations to make sure the UX is smooth
@@ -60,6 +60,7 @@ export interface InputProps extends Omit<TextInputProps, "placeholder"> {
   onHintPress?: () => void
   onSelectTap?: () => void
   optional?: boolean
+  onChangeText?: (text: string, unmaskedText: string) => void
   /**
    * The placeholder can be an array of string, specifically for android, because of a bug.
    * On ios, the longest string will always be picked, as ios can add ellipsis.
@@ -87,6 +88,15 @@ export interface InputProps extends Omit<TextInputProps, "placeholder"> {
   showLimit?: boolean
   title?: string
   unit?: string | undefined | null
+  /**
+   * A mask to apply to the input value.
+   * Make sure to use mask values using only the digit 9 and non-digit characters.
+   *
+   * @example
+   * <Input mask="999-99-9999" />
+   * <Input mask="(999)-99-9999 999-99-9999" />
+   * <Input mask="999-99-9999 999-99-9999 999-99-9999" />
+   */
   mask?: string | string[] | undefined
 }
 

--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -27,6 +27,7 @@ import {
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated"
 import styled from "styled-components"
 import { INPUT_VARIANTS, InputState, InputVariant, getInputState, getInputVariant } from "./helpers"
+import { maskValue, unmaskText } from "./maskValue"
 import { EyeClosedIcon, EyeOpenedIcon, TriangleDown, XCircleIcon } from "../../svgs"
 import { useTheme } from "../../utils/hooks"
 import { useMeasure } from "../../utils/hooks/useMeasure"
@@ -86,6 +87,7 @@ export interface InputProps extends Omit<TextInputProps, "placeholder"> {
   showLimit?: boolean
   title?: string
   unit?: string | undefined | null
+  mask?: string | string[] | undefined
 }
 
 export const HORIZONTAL_PADDING = 15
@@ -114,6 +116,7 @@ export const Input = forwardRef<InputRef, InputProps>(
       hintText = "What's this?",
       icon,
       leftComponentWidth = LEFT_COMPONENT_WIDTH,
+      mask,
       selectComponentWidth = SELECT_COMPONENT_WIDTH,
       loading = false,
       onBlur,
@@ -136,7 +139,12 @@ export const Input = forwardRef<InputRef, InputProps>(
     const [focused, setIsFocused] = useState(false)
     const [delayedFocused, setDelayedFocused] = useState(false)
 
-    const [value, setValue] = useState(propValue ?? defaultValue)
+    const [value, setValue] = useState(
+      maskValue({
+        currentValue: propValue ?? defaultValue ?? "",
+        mask: mask,
+      })
+    )
 
     const [showPassword, setShowPassword] = useState(!secureTextEntry)
 
@@ -169,9 +177,15 @@ export const Input = forwardRef<InputRef, InputProps>(
       // If the prop value changes, update the local state
       // This optimisation is not needed if no propValue has been specified
       if (propValue !== undefined && propValue !== value) {
-        setValue(propValue)
+        setValue(maskValue({ currentValue: propValue || "", mask }))
       }
-    }, [propValue, value])
+    }, [propValue, value, mask])
+
+    useEffect(() => {
+      // If the mask value changes, update the value state to be formatted again
+      setValue(maskValue({ currentValue: value, mask }))
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [mask])
 
     const fontFamily = theme.fonts.sans.regular
 
@@ -207,10 +221,11 @@ export const Input = forwardRef<InputRef, InputProps>(
 
     const handleChangeText = useCallback(
       (text: string) => {
-        setValue(text)
-        onChangeText?.(text)
+        const newText = maskValue({ currentValue: text, mask: mask, previousValue: value })
+        setValue(newText)
+        onChangeText?.(newText, unmaskText(text))
       },
-      [onChangeText]
+      [onChangeText, value, mask]
     )
 
     const handleClear = useCallback(() => {

--- a/src/elements/Input/maskValue.tests.ts
+++ b/src/elements/Input/maskValue.tests.ts
@@ -1,0 +1,86 @@
+import { maskValue } from "./maskValue"
+
+const GERMANY_PHONE_MASKS = [
+  "999 999",
+  "999 9999",
+  "999 99999",
+  "999 999999",
+  "999 9999999",
+  "999 99999999",
+  "9999 99999999",
+]
+
+const TUNISIA_PHONE_MASK = "99 999 999"
+
+const UNITED_STATES_PHONE_MASK = "999 999 9999"
+
+describe(maskValue, () => {
+  it("leaves the value value alone if the user is deleting characters", () => {
+    expect(
+      maskValue({
+        currentValue: "017672458053",
+        mask: GERMANY_PHONE_MASKS,
+      })
+    ).toBe("0176 72458053")
+
+    expect(
+      maskValue({
+        currentValue: "17672458053",
+        mask: GERMANY_PHONE_MASKS,
+      })
+    ).toBe("176 72458053")
+
+    expect(
+      maskValue({
+        currentValue: "030901820",
+        mask: GERMANY_PHONE_MASKS,
+      })
+    ).toBe("030 901820")
+
+    expect(
+      maskValue({
+        currentValue: "901820",
+        mask: GERMANY_PHONE_MASKS,
+      })
+    ).toBe("901 820")
+
+    expect(
+      maskValue({
+        currentValue: "20335902",
+        mask: TUNISIA_PHONE_MASK,
+      })
+    ).toBe("20 335 902")
+  })
+
+  it("works with empty strings", () => {
+    expect(
+      maskValue({
+        currentValue: "",
+        mask: GERMANY_PHONE_MASKS,
+      })
+    ).toBe("")
+
+    expect(
+      maskValue({
+        currentValue: "",
+        mask: "",
+      })
+    ).toBe("")
+  })
+
+  it("formats a given phone number to the given country's default format", () => {
+    expect(
+      maskValue({
+        currentValue: "7825577664",
+        mask: UNITED_STATES_PHONE_MASK,
+      })
+    ).toBe("782 557 7664")
+
+    expect(
+      maskValue({
+        currentValue: "782557766",
+        mask: UNITED_STATES_PHONE_MASK,
+      })
+    ).toBe("782 557 766")
+  })
+})

--- a/src/elements/Input/maskValue.ts
+++ b/src/elements/Input/maskValue.ts
@@ -1,0 +1,55 @@
+const maskString = (value: string, mask: string) => {
+  let result = mask.replace(/9/g, "_")
+  for (const digit of value.replace(/\D/g, "")) {
+    if (result.includes("_")) {
+      result = result.replace("_", digit)
+    } else {
+      result = result + digit
+    }
+  }
+  if (result.includes("_")) {
+    result = result.slice(0, result.indexOf("_"))
+  }
+  return result
+}
+export const maskValue = ({
+  currentValue,
+  mask,
+  previousValue = "",
+}: {
+  currentValue: string
+  mask: string | string[] | undefined
+  previousValue?: string
+}) => {
+  if (!currentValue || !mask || mask.length === 0) {
+    return currentValue
+  }
+
+  const value = unmaskText(currentValue)
+
+  if (previousValue && previousValue.length > currentValue.length) {
+    // user is deleting, don't mess with the format
+    return currentValue
+  }
+
+  if (typeof mask === "string") {
+    return maskString(currentValue, mask)
+  } else {
+    if (value.length <= unmaskText(mask[0]).length) {
+      return maskString(value, mask[0])
+    } else {
+      const nearestMask =
+        [...mask].reverse().find((m) => {
+          if (value.length >= unmaskText(m).length) {
+            return true
+          }
+          return false
+        }) || mask[0]
+
+      return maskString(value, nearestMask)
+    }
+  }
+}
+
+// Helper method to clean the mask and remove all non-digits and spaces
+export const unmaskText = (mask: string) => mask.replace(/\W/g, "")


### PR DESCRIPTION
### Description

Add support to masking values for the Input component.

In order to add a mask, you will need to simply provide a string or an array of strings of masks. The mask value should be composed of the digit `9` along with non numeric digits. example: `(999) 9999-999`

https://github.com/artsy/palette-mobile/assets/11945712/363dfb40-ddd3-4c8d-9fb2-a041a4228fc5


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
