### PR TITLE
fix(Input): proper typing and initial state

### DIFF
--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -231,12 +231,13 @@ export const Input = forwardRef<InputRef, InputProps>(
 
     const handleChangeText = useCallback(
       (text: string) => {
-        const newText = maskValue({ currentValue: text, mask: mask, previousValue: value }) || ""
-        setValue(newText)
         if (mask) {
+          const newText = maskValue({ currentValue: text, mask: mask, previousValue: value }) || ""
+          setValue(newText)
           onChangeText?.(newText, unmaskText(text))
         } else {
-          onChangeText?.(newText)
+          setValue(text)
+          onChangeText?.(text)
         }
       },
       [onChangeText, value, mask]

--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -60,7 +60,7 @@ export interface InputProps extends Omit<TextInputProps, "placeholder" | "onChan
   onHintPress?: () => void
   onSelectTap?: () => void
   optional?: boolean
-  onChangeText?: (text: string, unmaskedText: string) => void
+  onChangeText?: (text: string, unmaskedText?: string) => void
   /**
    * The placeholder can be an array of string, specifically for android, because of a bug.
    * On ios, the longest string will always be picked, as ios can add ellipsis.
@@ -151,7 +151,7 @@ export const Input = forwardRef<InputRef, InputProps>(
 
     const [value, setValue] = useState(
       maskValue({
-        currentValue: propValue ?? defaultValue ?? "",
+        currentValue: propValue ?? defaultValue,
         mask: mask,
       })
     )
@@ -231,9 +231,13 @@ export const Input = forwardRef<InputRef, InputProps>(
 
     const handleChangeText = useCallback(
       (text: string) => {
-        const newText = maskValue({ currentValue: text, mask: mask, previousValue: value })
+        const newText = maskValue({ currentValue: text, mask: mask, previousValue: value }) || ""
         setValue(newText)
-        onChangeText?.(newText, unmaskText(text))
+        if (mask) {
+          onChangeText?.(newText, unmaskText(text))
+        } else {
+          onChangeText?.(newText)
+        }
       },
       [onChangeText, value, mask]
     )

--- a/src/elements/Input/maskValue.ts
+++ b/src/elements/Input/maskValue.ts
@@ -17,7 +17,7 @@ export const maskValue = ({
   mask,
   previousValue = "",
 }: {
-  currentValue: string
+  currentValue: string | undefined
   mask: string | string[] | undefined
   previousValue?: string
 }) => {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes outstanding issues in https://github.com/artsy/eigen/pull/10407 by making the following changes:
- Fix the type of the `onChangeText`
- Allow for `undefined` as a valid initial state


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
