### PR TITLE
feat(Button): respect variant style given loading state

### DIFF
--- a/.storybook/storybook.requires.js
+++ b/.storybook/storybook.requires.js
@@ -32,6 +32,7 @@ const getStories = () => {
     require("../src/elements/BackButton/BackButton.stories.tsx"),
     require("../src/elements/Banner/Banner.stories.tsx"),
     require("../src/elements/Box/Box.stories.tsx"),
+    require("../src/elements/Button/Button.stories.tsx"),
     require("../src/elements/ButtonNew/Button.stories.tsx"),
     require("../src/elements/Checkbox/Checkbox.stories.tsx"),
     require("../src/elements/Collapse/Collapse.stories.tsx"),

--- a/src/elements/Button/Button.stories.tsx
+++ b/src/elements/Button/Button.stories.tsx
@@ -1,0 +1,100 @@
+import { capitalize } from "lodash"
+import { useState } from "react"
+import { Button, ButtonProps } from "./Button"
+import { DataList, List } from "../../storybook/helpers"
+import { Wrap } from "../../utils/Wrap"
+import { NoUndefined } from "../../utils/types"
+import { Flex } from "../Flex"
+import { LinkText } from "../Text"
+
+const sizes: Array<NoUndefined<ButtonProps["size"]>> = ["small", "large"]
+const variants: Array<NoUndefined<ButtonProps["variant"]>> = [
+  "fillDark",
+  "fillLight",
+  "fillGray",
+  "fillSuccess",
+  "outline",
+  "outlineGray",
+  "outlineLight",
+  "text",
+]
+
+export default {
+  title: "Button",
+  component: Button,
+}
+
+export const Sizes = () => (
+  <DataList
+    data={sizes}
+    renderItem={({ item: size }) => (
+      <Button size={size} onPress={() => console.log(`tapped ${size}`)}>
+        {capitalize(size)}
+      </Button>
+    )}
+  />
+)
+
+export const States = () => {
+  const [variant, setVariant] = useState<NoUndefined<ButtonProps["variant"]>>("fillDark")
+
+  return (
+    <List>
+      <Flex flexDirection="row" flexWrap="wrap" px={2}>
+        {variants.map((v) => (
+          <LinkText color="orange" onPress={() => setVariant(v)} mr="2">
+            {v}
+          </LinkText>
+        ))}
+      </Flex>
+      <Button variant={variant} onPress={() => console.log(`tapped`)} longestText="Regular YEA">
+        Regular
+      </Button>
+      <Button variant={variant} onPress={() => console.log(`tapped`)} disabled>
+        Disabled
+      </Button>
+      <Button variant={variant} onPress={() => console.log(`tapped`)} loading>
+        Loading
+      </Button>
+    </List>
+  )
+}
+
+export const Variants = () => (
+  <DataList
+    data={variants}
+    renderItem={({ item: variant }) => (
+      <Wrap if={variant === "outlineLight" || variant === "fillLight"}>
+        <Flex backgroundColor="pink" p={1}>
+          <Wrap.Content>
+            <Button variant={variant} onPress={() => console.log(`tapped ${variant}`)}>
+              {variant}
+            </Button>
+          </Wrap.Content>
+        </Flex>
+      </Wrap>
+    )}
+  />
+)
+
+export const VariantsLoading = () => (
+  <DataList
+    data={variants}
+    renderItem={({ item: variant }) => {
+      if (variant !== "outlineLight") {
+        return (
+          <Button variant={variant} loading onPress={() => console.log(`tapped ${variant}`)}>
+            {variant}
+          </Button>
+        )
+      }
+      return (
+        <Flex backgroundColor="pink" py={0.5}>
+          <Button variant={variant} loading onPress={() => console.log(`tapped ${variant}`)}>
+            {variant}
+          </Button>
+        </Flex>
+      )
+    }}
+  />
+)

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -6,7 +6,7 @@ import { config } from "react-spring"
 // @ts-ignore
 import { animated, Spring } from "react-spring/renderprops-native"
 import styled from "styled-components/native"
-import { SpacingUnit } from "../../types"
+import { Color, SpacingUnit } from "../../types"
 import { useColor } from "../../utils/hooks"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex/Flex"
@@ -112,8 +112,6 @@ export const Button: React.FC<ButtonProps> = ({
     }
   }
 
-  const spinnerColor = variant === "text" ? "blue100" : "white100"
-
   const handlePress = (event: GestureResponderEvent) => {
     if (onPress === undefined || onPress === null) {
       return
@@ -214,19 +212,19 @@ export const Button: React.FC<ButtonProps> = ({
                   >
                     {children}
                   </AnimatedText>
-                  {iconPosition === "right" && !!icon ? (
+                  {iconPosition === "right" && !!icon && (
                     <>
                       <Spacer x={0.5} />
                       {icon}
                     </>
-                  ) : null}
+                  )}
                 </Flex>
 
-                {displayState === DisplayState.Loading ? (
+                {displayState === DisplayState.Loading && (
                   <SpinnerContainer>
-                    <Spinner size={size} color={spinnerColor} />
+                    <Spinner size={size} color={to.loaderColor} />
                   </SpinnerContainer>
-                ) : null}
+                )}
               </Flex>
             </AnimatedContainer>
           </Flex>
@@ -244,6 +242,7 @@ const useStyleForVariantAndState = (
   borderColor: string
   borderWidth?: number
   textColor: string
+  loaderColor: Color
   textDecorationLine?: TextStyle["textDecorationLine"]
 } => {
   const color = useColor()
@@ -251,14 +250,6 @@ const useStyleForVariantAndState = (
   const retval = {
     textDecorationLine: "none",
   } as ReturnType<typeof useStyleForVariantAndState>
-
-  if (state === DisplayState.Loading) {
-    retval.backgroundColor = variant === "text" ? color("black10") : color("blue100")
-    retval.borderColor = "rgba(0, 0, 0, 0)"
-    retval.borderWidth = 0
-    retval.textColor = "rgba(0, 0, 0, 0)"
-    return retval
-  }
 
   switch (variant) {
     case "fillDark":
@@ -272,13 +263,19 @@ const useStyleForVariantAndState = (
           retval.backgroundColor = color("black30")
           retval.borderColor = color("black30")
           break
+        case DisplayState.Loading:
+          retval.backgroundColor = color("black100")
+          retval.borderColor = color("black100")
+          retval.textColor = "rgba(0, 0, 0, 0)"
+          retval.loaderColor = "white100"
+          break
         case DisplayState.Pressed:
           retval.backgroundColor = color("blue100")
           retval.borderColor = color("blue100")
           retval.textDecorationLine = "underline"
           break
         default:
-          assertNever(state)
+          null
       }
       break
 
@@ -294,6 +291,12 @@ const useStyleForVariantAndState = (
           retval.borderColor = color("black30")
           retval.textColor = color("white100")
           break
+        case DisplayState.Loading:
+          retval.backgroundColor = color("white100")
+          retval.borderColor = color("white100")
+          retval.textColor = "rgba(0, 0, 0, 0)"
+          retval.loaderColor = "black100"
+          break
         case DisplayState.Pressed:
           retval.backgroundColor = color("blue100")
           retval.borderColor = color("blue100")
@@ -301,7 +304,7 @@ const useStyleForVariantAndState = (
           retval.textDecorationLine = "underline"
           break
         default:
-          assertNever(state)
+          null
       }
       break
 
@@ -317,6 +320,12 @@ const useStyleForVariantAndState = (
           retval.borderColor = color("black30")
           retval.textColor = color("white100")
           break
+        case DisplayState.Loading:
+          retval.backgroundColor = color("black10")
+          retval.borderColor = color("black10")
+          retval.textColor = "rgba(0, 0, 0, 0)"
+          retval.loaderColor = "black100"
+          break
         case DisplayState.Pressed:
           retval.backgroundColor = color("blue100")
           retval.borderColor = color("blue100")
@@ -324,7 +333,7 @@ const useStyleForVariantAndState = (
           retval.textDecorationLine = "underline"
           break
         default:
-          assertNever(state)
+          null
       }
       break
 
@@ -339,13 +348,19 @@ const useStyleForVariantAndState = (
           retval.backgroundColor = color("blue100")
           retval.borderColor = color("blue100")
           break
+        case DisplayState.Loading:
+          retval.backgroundColor = color("blue100")
+          retval.borderColor = color("blue100")
+          retval.textColor = "rgba(0, 0, 0, 0)"
+          retval.loaderColor = "white100"
+          break
         case DisplayState.Pressed:
           retval.backgroundColor = color("blue10")
           retval.borderColor = color("blue10")
           retval.textDecorationLine = "underline"
           break
         default:
-          assertNever(state)
+          null
       }
       break
 
@@ -361,6 +376,12 @@ const useStyleForVariantAndState = (
           retval.borderColor = color("black30")
           retval.textColor = color("black30")
           break
+        case DisplayState.Loading:
+          retval.backgroundColor = color("white100")
+          retval.borderColor = color("black60")
+          retval.textColor = "rgba(0, 0, 0, 0)"
+          retval.loaderColor = "black100"
+          break
         case DisplayState.Pressed:
           retval.backgroundColor = color("blue100")
           retval.borderColor = color("blue100")
@@ -368,7 +389,7 @@ const useStyleForVariantAndState = (
           retval.textDecorationLine = "underline"
           break
         default:
-          assertNever(state)
+          null
       }
       break
 
@@ -384,6 +405,12 @@ const useStyleForVariantAndState = (
           retval.borderColor = color("black30")
           retval.textColor = color("black30")
           break
+        case DisplayState.Loading:
+          retval.backgroundColor = color("white100")
+          retval.borderColor = color("black30")
+          retval.textColor = "rgba(0, 0, 0, 0)"
+          retval.loaderColor = "black100"
+          break
         case DisplayState.Pressed:
           retval.backgroundColor = color("blue100")
           retval.borderColor = color("blue100")
@@ -391,7 +418,7 @@ const useStyleForVariantAndState = (
           retval.textDecorationLine = "underline"
           break
         default:
-          assertNever(state)
+          null
       }
       break
 
@@ -407,14 +434,20 @@ const useStyleForVariantAndState = (
           retval.borderColor = color("black30")
           retval.textColor = color("black30")
           break
+        case DisplayState.Loading:
+          retval.backgroundColor = "rgba(0, 0, 0, 0)"
+          retval.borderColor = color("white100")
+          retval.textColor = "rgba(0, 0, 0, 0)"
+          retval.loaderColor = "white100"
+          break
         case DisplayState.Pressed:
           retval.backgroundColor = color("blue100")
           retval.borderColor = color("blue100")
-          retval.textColor = color("white100")
+          retval.textColor = "rgba(0, 0, 0, 0)"
           retval.textDecorationLine = "underline"
           break
         default:
-          assertNever(state)
+          null
       }
       break
 
@@ -428,17 +461,21 @@ const useStyleForVariantAndState = (
         case DisplayState.Disabled:
           retval.textColor = color("black30")
           break
+        case DisplayState.Loading:
+          retval.textColor = "rgba(0, 0, 0, 0)"
+          retval.loaderColor = "blue100"
+          break
         case DisplayState.Pressed:
           retval.textColor = color("blue100")
           retval.textDecorationLine = "underline"
           break
         default:
-          assertNever(state)
+          null
       }
       break
 
     default:
-      assertNever(variant)
+      null
   }
 
   return retval

--- a/src/elements/ButtonNew/Button.stories.tsx
+++ b/src/elements/ButtonNew/Button.stories.tsx
@@ -27,7 +27,7 @@ const variants: Array<NoUndefined<ButtonProps["variant"]>> = [
 ]
 
 export default {
-  title: "Button",
+  title: "ButtonNew",
   component: Button,
 }
 


### PR DESCRIPTION
### Description

I realised we never moved out to use the ButtonNew(which is neat and has the loading state respecting the variant).
So, this PR brings the stories to the Button we use and uses the property styling given loading state with all variants supported by it.

Before:

https://github.com/artsy/palette-mobile/assets/15792853/e738fbaf-c437-4229-9c08-db96aa29c8ed

After:

https://github.com/artsy/palette-mobile/assets/15792853/c826e479-8109-4e82-acef-5a79a0ff3a07





