### PR TITLE
feat: add select/copy support to text fields by default

### DIFF
--- a/src/elements/Text/Text.tsx
+++ b/src/elements/Text/Text.tsx
@@ -52,6 +52,7 @@ export const Text = forwardRef(
     return (
       <InnerStyledText
         ref={ref}
+        selectable={true}
         style={[
           ...nativeTextStyle,
           { textAlignVertical: "center" }, // android renders text higher by default, so we bring it down to be consistent with ios

--- a/src/elements/Text/Text.tsx
+++ b/src/elements/Text/Text.tsx
@@ -26,6 +26,7 @@ export interface TextProps extends RNTextProps, InnerStyledTextProps {
   maxChars?: number
   underline?: boolean
   maxWidth?: boolean
+  selectable?: boolean
 }
 
 export const Text = forwardRef(
@@ -38,6 +39,7 @@ export const Text = forwardRef(
       weight = "regular",
       underline = false,
       maxWidth = false,
+      selectable = true,
       style,
       children,
       ...restProps
@@ -52,7 +54,7 @@ export const Text = forwardRef(
     return (
       <InnerStyledText
         ref={ref}
-        selectable={true}
+        selectable={selectable}
         style={[
           ...nativeTextStyle,
           { textAlignVertical: "center" }, // android renders text higher by default, so we bring it down to be consistent with ios


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This just sets selectable prop to true by default for Text components. 
Other option is to set to false by default and selectively enable in places we want it, are there places we don't want it?

<details>
<summary>
Before
</summary>

![not-selectable](https://github.com/artsy/palette-mobile/assets/49686530/d8d5ef55-7add-4808-8e7f-2dec565825a7)

</details>


<details>
<summary>
After
</summary>

![selectable](https://github.com/artsy/palette-mobile/assets/49686530/0a261e30-538e-40e1-acc5-adcda371f2c6)

</details>




