### PR TITLE
feat(Message): makes title optional

### DIFF
--- a/src/elements/Message/Message.stories.tsx
+++ b/src/elements/Message/Message.stories.tsx
@@ -12,6 +12,7 @@ storiesOf("Message", module)
       <Message variant="default" title="Without Close Button">
         <Text>Text</Text>
       </Message>
+      <Message variant="default" text="Without title" />
       <Message variant="default" showCloseButton title="Title" text="Text" />
       <Message
         variant="default"

--- a/src/elements/Message/Message.tsx
+++ b/src/elements/Message/Message.tsx
@@ -17,7 +17,7 @@ export interface MessageProps {
   showCloseButton?: boolean
   testID?: string
   text?: string
-  title: string
+  title?: string
   titleStyle?: TextProps
   variant?: MessageVariant
 }
@@ -79,9 +79,11 @@ export const Message: React.FC<MessageProps> = ({
                   <IconComponent />
                 </Flex>
               )}
-              <Text pr={2} variant="xs" color={color(colors[variant].title)} {...titleStyle}>
-                {title}
-              </Text>
+              {!!title && (
+                <Text pr={2} variant="xs" color={color(colors[variant].title)} {...titleStyle}>
+                  {title}
+                </Text>
+              )}
             </Flex>
             {!!text && (
               <Text variant="xs" color={color(colors[variant].text)} {...bodyTextStyle}>


### PR DESCRIPTION
This PR is related to [DIA-717]

### Description

Makes the `title` optional in the `Message` element. We don't have strict rules that the title must be always present, palette web also offers this flexibility, but this PR only enables that.

![Simulator Screenshot - iPhone 14 - 2024-07-10 at 14 29 05](https://github.com/artsy/palette-mobile/assets/15792853/b9a56093-54b0-45e0-8547-6154938eeafc)



[DIA-717]: https://artsyproduct.atlassian.net/browse/DIA-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ