### PR TITLE
fix: multiline input scrolling

### DIFF
--- a/src/elements/Input/Input.tests.tsx
+++ b/src/elements/Input/Input.tests.tsx
@@ -69,4 +69,10 @@ describe("Input", () => {
     expect(queryByLabelText("hide password button")).toBeFalsy()
     getByLabelText("show password button")
   })
+
+  it("enables scrolling when multiline is true", () => {
+    const { getByTestId } = renderWithWrappers(<Input testID={testID} multiline />)
+
+    expect(getByTestId(testID).props.scrollEnabled).toBe(true)
+  })
 })

--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -695,7 +695,7 @@ export const Input = forwardRef<InputRef, InputProps>(
           onLayout={(event) => {
             setInputWidth(event.nativeEvent.layout.width)
           }}
-          scrollEnabled={false}
+          scrollEnabled={props.multiline}
           editable={!disabled}
           textAlignVertical={props.multiline ? "top" : "center"}
           ref={inputRef as RefObject<TextInput>}


### PR DESCRIPTION
This PR addresses a bug where scrolling was always disabled for input fields, including multiline ones. The result is that none of the multiline inputs in Eigen can display more than 3 lines of text to users.

| Before | After |
|-------|-------|
| ![scroll-disabled](https://github.com/user-attachments/assets/4c52091b-4c7d-4386-a06d-5acadec2d546) | ![scroll-enabled](https://github.com/user-attachments/assets/634dc009-6a65-42a8-ba3e-afaa85e8f01a) |
