### PR TITLE
feat: add tab.flashlist support

### DIFF
--- a/src/elements/Tabs/TabFlashList.tsx
+++ b/src/elements/Tabs/TabFlashList.tsx
@@ -1,0 +1,22 @@
+import { FlashListProps } from "@shopify/flash-list"
+import { Tabs } from "react-native-collapsible-tab-view"
+import { useListenForTabContentScroll } from "./hooks/useListenForTabContentScroll"
+import { useSpace } from "../../utils/hooks/useSpace"
+
+export function TabFlashList<T>(props: FlashListProps<T>) {
+  useListenForTabContentScroll()
+
+  const space = useSpace()
+
+  const contentContainerStyle = (props.contentContainerStyle ?? {}) as object
+
+  return (
+    <Tabs.FlashList
+      contentContainerStyle={{
+        paddingHorizontal: space(2),
+        ...contentContainerStyle,
+      }}
+      {...props}
+    />
+  )
+}

--- a/src/elements/Tabs/Tabs.ts
+++ b/src/elements/Tabs/Tabs.ts
@@ -6,6 +6,7 @@ import {
   useHeaderMeasurements,
 } from "react-native-collapsible-tab-view"
 import { SubTabBar } from "./SubTabBar"
+import { TabFlashList } from "./TabFlashList"
 import { TabFlatList } from "./TabFlatList"
 import { TabMasonry } from "./TabMasonry"
 import { TabScrollView } from "./TabScrollView"
@@ -15,6 +16,7 @@ import { useListenForTabContentScroll } from "./hooks/useListenForTabContentScro
 
 export const Tabs = Object.assign(TabsContainer, {
   FlatList: TabFlatList,
+  FlashList: TabFlashList,
   Masonry: TabMasonry,
   Lazy: BaseTabs.Lazy,
   ScrollView: TabScrollView,


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Adds flashlist support for Tabs.FlashList

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.2.25--canary.247.2306.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@13.2.25--canary.247.2306.0
  # or 
  yarn add @artsy/palette-mobile@13.2.25--canary.247.2306.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
