### PR TITLE
build(deps): bumps react-native-reanimated from 3.3.0 to 3.6.3

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -520,35 +520,10 @@ PODS:
     - React-Core
   - RNReactNativeHapticFeedback (1.14.0):
     - React-Core
-  - RNReanimated (3.3.0):
-    - DoubleConversion
-    - FBLazyVector
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
-    - React-callinvoker
+  - RNReanimated (3.6.3):
+    - RCT-Folly (= 2021.07.22.00)
     - React-Core
-    - React-Core/DevSupport
-    - React-Core/RCTWebSocket
-    - React-CoreModules
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-RCTActionSheet
-    - React-RCTAnimation
-    - React-RCTAppDelegate
-    - React-RCTBlob
-    - React-RCTImage
-    - React-RCTLinking
-    - React-RCTNetwork
-    - React-RCTSettings
-    - React-RCTText
     - ReactCommon/turbomodule/core
-    - Yoga
   - RNSVG (14.1.0):
     - React-Core
   - SDWebImage (5.11.1):
@@ -825,7 +800,7 @@ SPEC CHECKSUMS:
   RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
   RNFlashList: b521ebdd7f9352673817f1d98e8bdc0c8cf8545b
   RNReactNativeHapticFeedback: 1e3efeca9628ff9876ee7cdd9edec1b336913f8c
-  RNReanimated: 9f7068e43b9358a46a688d94a5a3adb258139457
+  RNReanimated: 548e621fe2e12b6bdccbc48ed5e5361d9822c775
   RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "react-native-flipper": "0.178.1",
     "react-native-haptic-feedback": "1.14.0",
     "react-native-linear-gradient": "2.6.2",
-    "react-native-reanimated": "^3.3.0",
+    "react-native-reanimated": "3.6.3",
     "react-native-safe-area-context": "4.5.0",
     "react-native-svg": "14.1.0",
     "react-test-renderer": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10277,10 +10277,10 @@ react-native-popover-view@^5.1.7:
     deprecated-react-native-prop-types "^2.3.0"
     prop-types "^15.8.1"
 
-react-native-reanimated@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.3.0.tgz#80f9d58e28fddf62fe4c1bc792337b8ab57936ab"
-  integrity sha512-LzfpPZ1qXBGy5BcUHqw3pBC0qSd22qXS3t8hWSbozXNrBkzMhhOrcILE/nEg/PHpNNp1xvGOW8NwpAMF006roQ==
+react-native-reanimated@3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.6.3.tgz#859cf2320e37c80e3a21e19db24f82c34d6d3ded"
+  integrity sha512-2KkkPozoIvDbJcHuf8qeyoLROXQxizSi+2CTCkuNVkVZOxxY4B0Omvgq61aOQhSZUh/649x1YHoAaTyGMGDJUw==
   dependencies:
     "@babel/plugin-transform-object-assign" "^7.16.7"
     "@babel/preset-typescript" "^7.16.7"


### PR DESCRIPTION
This PR resolves [PHIRE-1180] <!-- eg [PROJECT-XXXX] -->

### Description

Bumps `react-native-reanimated` from 3.3.0 to 3.6.3 in order to be able to bump the `react-native` dependency without issues in the future.

Do not merge before we manage to test + bump reanimated in both eigen / energy.

**bonus:** we can get rid of the patch in eigen since it was fixed in `3.4.0`

### TODO

- [x] Test iOS `eigen`
- [x] Test Android `eigen`
- [x] Test Android `energy`
- [x] Test iOS `energy`

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[PHIRE-1180]: https://artsyproduct.atlassian.net/browse/PHIRE-1180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ