### PR TITLE
fix: text being cropped on android

### DIFF
--- a/src/elements/Text/Text.tsx
+++ b/src/elements/Text/Text.tsx
@@ -39,7 +39,6 @@ export const Text = forwardRef(
       weight = "regular",
       underline = false,
       maxWidth = false,
-      selectable = true,
       style,
       children,
       ...restProps
@@ -54,7 +53,6 @@ export const Text = forwardRef(
     return (
       <InnerStyledText
         ref={ref}
-        selectable={selectable}
         style={[
           ...nativeTextStyle,
           { textAlignVertical: "center" }, // android renders text higher by default, so we bring it down to be consistent with ios

--- a/src/elements/Text/Text.tsx
+++ b/src/elements/Text/Text.tsx
@@ -39,6 +39,7 @@ export const Text = forwardRef(
       weight = "regular",
       underline = false,
       maxWidth = false,
+      selectable = false,
       style,
       children,
       ...restProps
@@ -53,6 +54,7 @@ export const Text = forwardRef(
     return (
       <InnerStyledText
         ref={ref}
+        selectable={selectable}
         style={[
           ...nativeTextStyle,
           { textAlignVertical: "center" }, // android renders text higher by default, so we bring it down to be consistent with ios


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
Fix text being cropped on android

After removing the prop `selectable` or setting it to false the issue is gone.
I think it is safe to set `selectable` prop to false. In fact, I don't think it is even working at the moment, I could not reproduce the desired behaviour shown [here](https://github.com/artsy/eigen/pull/4359).
If we want to let the users select the text again we can work on it some other time. So far, it looks like solving the bug with the text being cropped on android has a higher priority

[Bug appearance 1](https://artsy.slack.com/archives/C05EQL4R5N0/p1730282143154759), [Bug appearance 2](https://artsy.slack.com/archives/C07PRTJSD6G/p1729783543401549)

| Before | After |
| --- | --- |
| <img width="357" alt="image" src="https://github.com/user-attachments/assets/57b84bbc-1d5e-411e-9ebd-ea112a422117"> | <img width="348" alt="image" src="https://github.com/user-attachments/assets/169f8f52-1b4a-4143-b1cf-4cd5fe23304e"> | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
