### PR TITLE
chore: allow using uncontrolled inputs

### DIFF
--- a/src/elements/Input/Input.tests.tsx
+++ b/src/elements/Input/Input.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react-native"
+import { act, fireEvent, screen } from "@testing-library/react-native"
 import { Input } from "./Input"
 import { renderWithWrappers } from "../../utils/tests/renderWithWrappers"
 
@@ -31,21 +31,19 @@ describe("Input", () => {
     getByText("input has an error")
   })
 
-  it("should render the clear button when input is not empty and pressing it should clear the input", () => {
-    const { getByDisplayValue, queryByDisplayValue, getByPlaceholderText, getByLabelText } =
-      renderWithWrappers(<Input placeholder="USD" enableClearButton />)
-    // placeholder is rendered
-    getByPlaceholderText("USD")
+  it("should render the clear button when input is not empty and pressing it should clear the input", async () => {
+    renderWithWrappers(<Input testID={testID} placeholder="USD" enableClearButton />)
+    act(() => {
+      fireEvent(screen.getByTestId(testID), "onChangeText", "Banksy")
+    })
 
-    fireEvent(getByPlaceholderText("USD"), "onChangeText", "Banksy")
+    screen.findByDisplayValue("Banksy")
 
-    getByDisplayValue("Banksy")
+    screen.getByLabelText("Clear input button")
 
-    getByLabelText("Clear input button")
+    fireEvent.press(screen.getByLabelText("Clear input button"))
 
-    fireEvent.press(getByLabelText("Clear input button"))
-
-    expect(queryByDisplayValue("Banksy")).toBeFalsy()
+    expect(screen.queryByDisplayValue("Banksy")).toBeFalsy()
   })
 
   it("should show the correct show/hide password icon", () => {

--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -49,6 +49,10 @@ export interface InputProps extends Omit<TextInputProps, "placeholder" | "onChan
    * These lead to some issues when the parent component wants further control of the value
    */
   disabled?: boolean
+  /**
+   * Enables the clear button
+   * @warning This prop only works if `value` is specified
+   */
   enableClearButton?: boolean
   error?: string
   fixedRightPlaceholder?: string

--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -98,6 +98,13 @@ export interface InputProps extends Omit<TextInputProps, "placeholder" | "onChan
    * <Input mask="999-99-9999 999-99-9999 999-99-9999" />
    */
   mask?: string | string[] | undefined
+  /**
+   * @warning This prop affects the performance of the input
+   * and should be avoided if possible.
+   * Use `defaultValue` instead.
+   * See: https://github.com/facebook/react-native-website/pull/4247
+   */
+  value?: string | undefined
 }
 
 export const HORIZONTAL_PADDING = 15
@@ -687,7 +694,8 @@ export const Input = forwardRef<InputRef, InputProps>(
         {renderAnimatedTitle()}
 
         <AnimatedStyledInput
-          value={value}
+          // Only use a controlled input if specified
+          {...(propValue || mask ? { value } : {})}
           onChangeText={handleChangeText}
           style={[styles, textInputAnimatedStyles]}
           onFocus={handleFocus}

--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -695,7 +695,7 @@ export const Input = forwardRef<InputRef, InputProps>(
 
         <AnimatedStyledInput
           // Only use a controlled input if specified
-          {...(propValue || mask ? { value } : {})}
+          {...((propValue !== undefined && propValue !== null) || mask ? { value } : {})}
           onChangeText={handleChangeText}
           style={[styles, textInputAnimatedStyles]}
           onFocus={handleFocus}


### PR DESCRIPTION
### Description

When trying to log in using the new flow, I noticed some keystrokes not making it. I did some investigation to see why this is happening since I was assuming we are using a non-controlled input for it so performance should not ideal. However, I noticed that:

1. We accidentally brought back the `value` prop [here](https://github.com/artsy/eigen/blob/323d364c69ac26ba67050672cbefaddddad5a075/src/app/Scenes/Onboarding/Auth2/scenes/ForgotPasswordStep.tsx#L123)
2. The value is being set in Palette Mobile, regardless of using it or not 😮 

Here I am trying my artsy mail mounirdhahri[at]artsymail.com
1. In the video on the left, you can see how it's missing some keystrokes
2. In the video on the right, it's working smoothly (apart from the few mistakes I made 😄 )

| When using a controlled input | When using a non-controlled input |
|--------|--------|
| <Video src="https://github.com/user-attachments/assets/b814bfaf-7adb-4b1b-8620-a2fc6df6480c" /> | <Video src="https://github.com/user-attachments/assets/f241e7ab-5ac2-4f6d-8509-ed1963c9b799" />
 | 









  
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
