### PR TITLE
refactor: proper use of useSharedValue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     "plugin:import/typescript",
     "plugin:react-hooks/recommended",
     "plugin:react/jsx-runtime",
+    "plugin:testing-library/react",
     "prettier", // "prettier" needs to be last!
   ],
   parserOptions: {
@@ -97,4 +98,11 @@ module.exports = {
     "react-native/no-inline-styles": OFF,
     "react/react-in-jsx-scope": OFF,
   },
+  overrides: [
+    {
+      // Test files only
+      files: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)"],
+      extends: ["plugin:testing-library/react"],
+    },
+  ],
 }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-storybook": "0.6.10",
-    "eslint-plugin-testing-library": "^5.10.2",
+    "eslint-plugin-testing-library": "6.4.0",
     "husky": "^8.0.3",
     "jest": "29.6.3",
     "jest-environment-jsdom": "29.4.2",

--- a/src/elements/Avatar/Avatar.tsx
+++ b/src/elements/Avatar/Avatar.tsx
@@ -1,4 +1,4 @@
-import { ImgHTMLAttributes, useState } from "react"
+import { ImgHTMLAttributes, useEffect, useState } from "react"
 import { Image } from "react-native"
 import Animated, {
   useAnimatedStyle,
@@ -51,17 +51,21 @@ export const Avatar = ({ src, initials, size = DEFAULT_SIZE }: AvatarProps) => {
 
   const opacity = useSharedValue(0)
 
-  opacity.value = withDelay(
-    100,
-    withTiming(1, {
-      duration: 200,
-      easing: Easing.sin,
-    })
-  )
+  useEffect(() => {
+    opacity.set(() =>
+      withDelay(
+        100,
+        withTiming(1, {
+          duration: 200,
+          easing: Easing.sin,
+        })
+      )
+    )
+  }, [loading])
 
   const style = useAnimatedStyle(() => {
     return {
-      opacity: loading ? 0 : opacity.value,
+      opacity: loading ? 0 : opacity.get(),
     }
   }, [loading])
 

--- a/src/elements/ButtonNew/Button.tests.tsx
+++ b/src/elements/ButtonNew/Button.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { Button } from "./Button"
 import { renderWithWrappers } from "../../utils/tests/renderWithWrappers"
 import { Spinner } from "../Spinner"
@@ -12,13 +12,13 @@ describe("Button", () => {
   it("invokes the onClick callback", () => {
     const onPress = jest.fn()
 
-    const { getByTestId } = renderWithWrappers(
+    renderWithWrappers(
       <Button testID="the-button" onPress={onPress}>
         wow
       </Button>
     )
 
-    fireEvent.press(getByTestId("the-button"))
+    fireEvent.press(screen.getByTestId("the-button"))
 
     expect(onPress).toHaveBeenCalled()
   })
@@ -26,13 +26,13 @@ describe("Button", () => {
   it("does not invoke the onClick callback if loading is true", () => {
     const onPress = jest.fn()
 
-    const { getByTestId } = renderWithWrappers(
+    renderWithWrappers(
       <Button testID="the-button" onPress={onPress} loading>
         wow
       </Button>
     )
 
-    fireEvent.press(getByTestId("the-button"))
+    fireEvent.press(screen.getByTestId("the-button"))
 
     expect(onPress).not.toHaveBeenCalled()
   })
@@ -40,13 +40,13 @@ describe("Button", () => {
   it("does not invoke the onClick callback if disabled is true", () => {
     const onPress = jest.fn()
 
-    const { getByTestId } = renderWithWrappers(
+    renderWithWrappers(
       <Button testID="the-button" onPress={onPress} disabled>
         wow
       </Button>
     )
 
-    fireEvent.press(getByTestId("the-button"))
+    fireEvent.press(screen.getByTestId("the-button"))
 
     expect(onPress).not.toHaveBeenCalled()
   })

--- a/src/elements/ButtonNew/Button.tsx
+++ b/src/elements/ButtonNew/Button.tsx
@@ -92,9 +92,11 @@ export const Button = ({
       return pressedV.value
     },
     (pressedVal) => {
-      return (pressAnimationProgress.value = withTiming(pressedVal, {
-        duration: ANIMATION_DURATION,
-      }))
+      return pressAnimationProgress.set(() =>
+        withTiming(pressedVal, {
+          duration: ANIMATION_DURATION,
+        })
+      )
     }
   )
 
@@ -143,12 +145,12 @@ export const Button = ({
     }
     return {
       backgroundColor: interpolateColor(
-        pressAnimationProgress.value,
+        pressAnimationProgress.get(),
         [0, 1],
         [colors.active.bg, colors.pressed.bg]
       ),
       borderColor: interpolateColor(
-        pressAnimationProgress.value,
+        pressAnimationProgress.get(),
         [0, 1],
         [colors.active.border, colors.pressed.border]
       ),
@@ -162,11 +164,11 @@ export const Button = ({
     }
     return {
       color: interpolateColor(
-        pressAnimationProgress.value,
+        pressAnimationProgress.get(),
         [0, 1],
         [colors.active.text, colors.pressed.text]
       ),
-      textDecorationLine: pressAnimationProgress.value > 0 ? "underline" : "none",
+      textDecorationLine: pressAnimationProgress.get() > 0 ? "underline" : "none",
     }
   })
 

--- a/src/elements/Dialog/Dialog.tests.tsx
+++ b/src/elements/Dialog/Dialog.tests.tsx
@@ -1,10 +1,10 @@
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { Dialog } from "./Dialog"
 import { renderWithWrappers } from "../../utils/tests/renderWithWrappers"
 
 describe("Dialog", () => {
   it("renders without error", () => {
-    const { getByText } = renderWithWrappers(
+    renderWithWrappers(
       <Dialog
         title="title"
         isVisible
@@ -15,11 +15,11 @@ describe("Dialog", () => {
       />
     )
 
-    expect(getByText("title")).toBeTruthy()
+    expect(screen.getByText("title")).toBeOnTheScreen()
   })
 
   it("should render details if it is passed", () => {
-    const { getByText } = renderWithWrappers(
+    renderWithWrappers(
       <Dialog
         title="title"
         detail="Some unique detail"
@@ -31,13 +31,13 @@ describe("Dialog", () => {
       />
     )
 
-    expect(getByText("Some unique detail")).toBeTruthy()
+    expect(screen.getByText("Some unique detail")).toBeOnTheScreen()
   })
 
   it("should render the primary action button", () => {
     const primaryActionMock = jest.fn()
 
-    const { getByTestId, getByText } = renderWithWrappers(
+    renderWithWrappers(
       <Dialog
         title="title"
         isVisible
@@ -47,18 +47,18 @@ describe("Dialog", () => {
         }}
       />
     )
-    const primaryButton = getByTestId("dialog-primary-action-button")
+    const primaryButton = screen.getByTestId("dialog-primary-action-button")
 
     fireEvent.press(primaryButton)
 
     expect(primaryActionMock).toHaveBeenCalled()
-    expect(getByText("Primary Action Button")).toBeTruthy()
+    expect(screen.getByText("Primary Action Button")).toBeOnTheScreen()
   })
 
   it("should render the secondary action button if it is passed", () => {
     const secondaryActionMock = jest.fn()
 
-    const { getByTestId, getByText } = renderWithWrappers(
+    renderWithWrappers(
       <Dialog
         title="title"
         isVisible
@@ -72,17 +72,17 @@ describe("Dialog", () => {
         }}
       />
     )
-    const secondaryButton = getByTestId("dialog-secondary-action-button")
+    const secondaryButton = screen.getByTestId("dialog-secondary-action-button")
 
     fireEvent.press(secondaryButton)
 
     expect(secondaryActionMock).toHaveBeenCalled()
-    expect(getByText("Secondary Action Button")).toBeTruthy()
+    expect(screen.getByText("Secondary Action Button")).toBeOnTheScreen()
   })
 
   it("should call onBackgroundPress when backdrop is pressed", () => {
     const onBackgroundPressMock = jest.fn()
-    const { getByTestId } = renderWithWrappers(
+    renderWithWrappers(
       <Dialog
         title="title"
         isVisible
@@ -94,7 +94,7 @@ describe("Dialog", () => {
       />
     )
 
-    fireEvent.press(getByTestId("dialog-backdrop"))
+    fireEvent.press(screen.getByTestId("dialog-backdrop"))
 
     expect(onBackgroundPressMock).toHaveBeenCalled()
   })

--- a/src/elements/Image/Image.tsx
+++ b/src/elements/Image/Image.tsx
@@ -56,13 +56,13 @@ export const Image: React.FC<ImageProps> = memo(
 
     const animatedStyles = useAnimatedStyle(() => {
       return {
-        opacity: withTiming(loading.value ? 0 : 1, { duration: 200, easing: Easing.sin }),
+        opacity: withTiming(loading.get() ? 0 : 1, { duration: 200, easing: Easing.sin }),
       }
     }, [])
 
     const onAnimationEnd = useCallback(() => {
       "worklet"
-      loading.value = false
+      loading.set(() => false)
       // No need to get the js thread involved here
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])

--- a/src/elements/Input/Input.tests.tsx
+++ b/src/elements/Input/Input.tests.tsx
@@ -6,31 +6,29 @@ describe("Input", () => {
   const testID = "input"
 
   it("renders an instance of native TextInput", () => {
-    const { getByTestId } = renderWithWrappers(<Input testID={testID} />)
+    renderWithWrappers(<Input testID={testID} />)
 
-    expect(getByTestId(testID).type).toEqual("TextInput")
+    expect(screen.getByTestId(testID).type).toEqual("TextInput")
   })
 
   it("uses correct font family", () => {
-    const { getByPlaceholderText } = renderWithWrappers(
-      <Input testID={testID} placeholder="input" />
-    )
+    renderWithWrappers(<Input testID={testID} placeholder="input" />)
 
-    expect(getByPlaceholderText("input")).toHaveStyle({ fontFamily: "Unica77LL-Regular" })
+    expect(screen.getByPlaceholderText("input")).toHaveStyle({ fontFamily: "Unica77LL-Regular" })
   })
 
   it("mutates given text as value", () => {
-    const { getByTestId, getByDisplayValue } = renderWithWrappers(<Input testID={testID} />)
+    renderWithWrappers(<Input testID={testID} />)
 
-    fireEvent.changeText(getByTestId(testID), "mockStr")
+    fireEvent.changeText(screen.getByTestId(testID), "mockStr")
 
-    getByDisplayValue("mockStr")
+    screen.getByDisplayValue("mockStr")
   })
 
   it("Shows an error message when input has an error", () => {
-    const { getByText } = renderWithWrappers(<Input value="" error="input has an error" />)
+    renderWithWrappers(<Input value="" error="input has an error" />)
 
-    getByText("input has an error")
+    screen.getByText("input has an error")
   })
 
   it("should render the clear button when input is not empty and pressing it should clear the input", async () => {
@@ -38,9 +36,7 @@ describe("Input", () => {
 
     fireEvent(screen.getByTestId(testID), "onChangeText", "Banksy")
 
-    screen.findByDisplayValue("Banksy")
-
-    screen.getByLabelText("Clear input button")
+    await screen.findByLabelText("Clear input button")
 
     fireEvent.press(screen.getByLabelText("Clear input button"))
 
@@ -48,30 +44,28 @@ describe("Input", () => {
   })
 
   it("should show the correct show/hide password icon", () => {
-    const { getByPlaceholderText, queryByLabelText, getByLabelText } = renderWithWrappers(
-      <Input placeholder="password" secureTextEntry />
-    )
+    renderWithWrappers(<Input placeholder="password" secureTextEntry />)
 
-    getByPlaceholderText("password")
+    screen.getByPlaceholderText("password")
 
-    getByLabelText("show password button")
+    screen.getByLabelText("show password button")
 
-    fireEvent(getByPlaceholderText("password"), "onChangeText", "123456")
+    fireEvent(screen.getByPlaceholderText("password"), "onChangeText", "123456")
 
-    fireEvent.press(getByLabelText("show password button"))
+    fireEvent.press(screen.getByLabelText("show password button"))
 
-    expect(queryByLabelText("show password button")).toBeFalsy()
-    getByLabelText("hide password button")
+    expect(screen.queryByLabelText("show password button")).toBeFalsy()
+    screen.getByLabelText("hide password button")
 
-    fireEvent.press(getByLabelText("hide password button"))
+    fireEvent.press(screen.getByLabelText("hide password button"))
 
-    expect(queryByLabelText("hide password button")).toBeFalsy()
-    getByLabelText("show password button")
+    expect(screen.queryByLabelText("hide password button")).toBeFalsy()
+    screen.getByLabelText("show password button")
   })
 
   it("enables scrolling when multiline is true", () => {
-    const { getByTestId } = renderWithWrappers(<Input testID={testID} multiline />)
+    renderWithWrappers(<Input testID={testID} multiline />)
 
-    expect(getByTestId(testID).props.scrollEnabled).toBe(true)
+    expect(screen.getByTestId(testID).props.scrollEnabled).toBe(true)
   })
 })

--- a/src/elements/Input/Input.tests.tsx
+++ b/src/elements/Input/Input.tests.tsx
@@ -35,9 +35,8 @@ describe("Input", () => {
 
   it("should render the clear button when input is not empty and pressing it should clear the input", async () => {
     renderWithWrappers(<Input testID={testID} placeholder="USD" enableClearButton />)
-    act(() => {
-      fireEvent(screen.getByTestId(testID), "onChangeText", "Banksy")
-    })
+
+    fireEvent(screen.getByTestId(testID), "onChangeText", "Banksy")
 
     screen.findByDisplayValue("Banksy")
 

--- a/src/elements/Input/Input.tests.tsx
+++ b/src/elements/Input/Input.tests.tsx
@@ -12,9 +12,11 @@ describe("Input", () => {
   })
 
   it("uses correct font family", () => {
-    const { getByTestId } = renderWithWrappers(<Input testID={testID} />)
+    const { getByPlaceholderText } = renderWithWrappers(
+      <Input testID={testID} placeholder="input" />
+    )
 
-    expect(getByTestId(testID).props.style[0].fontFamily).toEqual("Unica77LL-Regular")
+    expect(getByPlaceholderText("input")).toHaveStyle({ fontFamily: "Unica77LL-Regular" })
   })
 
   it("mutates given text as value", () => {

--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -311,15 +311,18 @@ export const Input = forwardRef<InputRef, InputProps>(
       }
     }, [fontFamily, space])
 
-    animatedState.value = getInputState({
-      isFocused: !!focused,
-      value: value,
-    })
+    useEffect(() => {
+      const inputState = getInputState({
+        isFocused: !!focused,
+        value: value,
+      })
+      animatedState.set(() => inputState)
+    }, [value, focused, animatedState])
 
     const textInputAnimatedStyles = useAnimatedStyle(() => {
       return {
-        borderColor: withTiming(INPUT_VARIANTS[variant][animatedState.value].inputBorderColor),
-        color: withTiming(INPUT_VARIANTS[variant][animatedState.value].inputTextColor),
+        borderColor: withTiming(INPUT_VARIANTS[variant][animatedState.get()].inputBorderColor),
+        color: withTiming(INPUT_VARIANTS[variant][animatedState.get()].inputTextColor),
       }
     })
 
@@ -333,16 +336,16 @@ export const Input = forwardRef<InputRef, InputProps>(
           : HORIZONTAL_PADDING
 
       return {
-        color: withTiming(INPUT_VARIANTS[variant][animatedState.value].labelColor),
-        top: withTiming(INPUT_VARIANTS[variant][animatedState.value].labelTop),
-        fontSize: withTiming(INPUT_VARIANTS[variant][animatedState.value].labelFontSize),
+        color: withTiming(INPUT_VARIANTS[variant][animatedState.get()].labelColor),
+        top: withTiming(INPUT_VARIANTS[variant][animatedState.get()].labelTop),
+        fontSize: withTiming(INPUT_VARIANTS[variant][animatedState.get()].labelFontSize),
         marginLeft: withTiming(marginLeft),
       }
     })
 
     const selectComponentStyles = useAnimatedStyle(() => {
       return {
-        borderColor: withTiming(INPUT_VARIANTS[variant][animatedState.value].inputBorderColor),
+        borderColor: withTiming(INPUT_VARIANTS[variant][animatedState.get()].inputBorderColor),
       }
     })
 

--- a/src/elements/Message/Message.tests.tsx
+++ b/src/elements/Message/Message.tests.tsx
@@ -1,41 +1,35 @@
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { Message } from "./Message"
 import { renderWithWrappers } from "../../utils/tests/renderWithWrappers"
 
 describe("Message", () => {
   it("it renders", () => {
-    const MessageComponent = renderWithWrappers(
-      <Message variant="default" title="title" text="text" />
-    )
+    renderWithWrappers(<Message variant="default" title="title" text="text" />)
 
-    expect(MessageComponent).toBeTruthy()
-
-    expect(MessageComponent.getByText("title")).toBeDefined()
-    expect(MessageComponent.getByText("text")).toBeDefined()
+    expect(screen.getByText("title")).toBeOnTheScreen()
+    expect(screen.getByText("text")).toBeOnTheScreen()
   })
 
   it("does not show close button when !showCloseButton", () => {
-    const { getByTestId } = renderWithWrappers(
-      <Message variant="default" title="title" text="text" />
-    )
-    expect(() => getByTestId("Message-close-button")).toThrow(
-      "Unable to find an element with testID: Message-close-button"
-    )
+    renderWithWrappers(<Message variant="default" title="title" text="text" />)
+
+    expect(screen.queryByTestId("Message-close-button")).not.toBeOnTheScreen()
   })
 
   it("shows close button when showCloseButton", () => {
-    const { getByTestId } = renderWithWrappers(
-      <Message variant="default" title="title" text="text" showCloseButton />
-    )
-    expect(getByTestId("Message-close-button")).toBeDefined()
+    renderWithWrappers(<Message variant="default" title="title" text="text" showCloseButton />)
+
+    expect(screen.getByTestId("Message-close-button")).toBeOnTheScreen()
   })
 
   it("fires onClose press event", () => {
     const onClose = jest.fn()
-    const { getByTestId } = renderWithWrappers(
+    renderWithWrappers(
       <Message variant="default" onClose={onClose} title="title" text="text" showCloseButton />
     )
-    fireEvent.press(getByTestId("Message-close-button"))
+
+    fireEvent.press(screen.getByTestId("Message-close-button"))
+
     expect(onClose).toHaveBeenCalled()
   })
 })

--- a/src/elements/Pill/Pill.tests.tsx
+++ b/src/elements/Pill/Pill.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react-native"
+import { fireEvent, render, screen } from "@testing-library/react-native"
 import { Pill } from "./Pill"
 import { Theme } from "../../Theme"
 
@@ -6,20 +6,20 @@ describe("Pill", () => {
   it("invokes the onClick callback", () => {
     const onPress = jest.fn()
 
-    const { getByText } = render(
+    render(
       <Theme>
         <Pill onPress={onPress}>wow</Pill>
       </Theme>
     )
 
-    fireEvent.press(getByText("wow"))
+    fireEvent.press(screen.getByText("wow"))
     expect(onPress).toHaveBeenCalled()
   })
 
   it("should not be pressable if disabled is passed", () => {
     const onPress = jest.fn()
 
-    const { getByText } = render(
+    render(
       <Theme>
         <Pill disabled onPress={onPress}>
           Press me
@@ -27,7 +27,7 @@ describe("Pill", () => {
       </Theme>
     )
 
-    fireEvent.press(getByText("Press me"))
+    fireEvent.press(screen.getByText("Press me"))
     expect(onPress).not.toHaveBeenCalled()
   })
 })

--- a/src/elements/ProgressBar/ProgressBar.tsx
+++ b/src/elements/ProgressBar/ProgressBar.tsx
@@ -34,13 +34,13 @@ export const ProgressBar = ({
   const width = useSharedValue(0)
   const progress = clamp(unclampedProgress, 0, 100)
   const progressAnim = useAnimatedStyle(() => {
-    return { width: `${width.value}%` }
+    return { width: `${width.get()}%` }
   })
 
   const [onCompletionCalled, setOnCompletionCalled] = useState(false)
 
   useEffect(() => {
-    width.value = withTiming(progress, { duration: animationDuration })
+    width.set(() => withTiming(progress, { duration: animationDuration }))
 
     if (progress === 100 && !onCompletionCalled) {
       onCompletion?.()

--- a/src/elements/Screen/hooks/useAnimatedHeaderScrolling.tsx
+++ b/src/elements/Screen/hooks/useAnimatedHeaderScrolling.tsx
@@ -4,7 +4,7 @@ import { NAVBAR_HEIGHT } from "../constants"
 
 export const useAnimatedHeaderScrolling = (scrollY: SharedValue<number>, scrollYOffset = 0) => {
   const listenForScroll = useSharedValue(true)
-  const [currScrollY, setCurrScrollY] = useState(scrollY.value)
+  const [currScrollY, setCurrScrollY] = useState(scrollY.get())
   const HEADER_HEIGHT = useMemo(() => NAVBAR_HEIGHT + scrollYOffset, [scrollYOffset])
 
   // Needed to run on JS thread
@@ -14,17 +14,17 @@ export const useAnimatedHeaderScrolling = (scrollY: SharedValue<number>, scrollY
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      listenForScroll.value = false
+      listenForScroll.set(() => false)
     }, 1000)
 
     return () => {
       clearTimeout(timer)
     }
-  }, [listenForScroll])
+  }, [listenForScroll.get()])
 
   useAnimatedReaction(
     () => {
-      return [scrollY.value, listenForScroll.value] as const
+      return [scrollY.get(), listenForScroll.get()] as const
     },
     ([animatedScrollY, isListeningForScroll], previousScroll) => {
       const [prevScrollY] = previousScroll ?? [0, false]

--- a/src/elements/Screen/hooks/useListenForScreenScroll.tsx
+++ b/src/elements/Screen/hooks/useListenForScreenScroll.tsx
@@ -10,7 +10,7 @@ export const useListenForScreenScroll = () => {
 
   const scrollHandler = useAnimatedScrollHandler({
     onScroll: (event) => {
-      animatedScrollY.value = event.contentOffset.y
+      animatedScrollY.set(() => event.contentOffset.y)
     },
   })
 

--- a/src/elements/Skeleton/Skeleton.tsx
+++ b/src/elements/Skeleton/Skeleton.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from "react"
+import { FC, ReactNode, useEffect } from "react"
 import Animated, {
   Easing,
   useAnimatedStyle,
@@ -22,9 +22,13 @@ import { Text, TextProps } from "../Text"
  */
 export const Skeleton: FC<{ children: ReactNode }> = ({ children }) => {
   const opacity = useSharedValue(0.5)
-  opacity.value = withRepeat(withTiming(1, { duration: 1000, easing: Easing.ease }), -1, true)
+
+  useEffect(() => {
+    opacity.set(() => withRepeat(withTiming(1, { duration: 1000, easing: Easing.ease }), -1, true))
+  }, [opacity])
+
   const fadeLoopAnim = useAnimatedStyle(() => {
-    return { opacity: opacity.value }
+    return { opacity: opacity.get() }
   }, [])
 
   return <Animated.View style={fadeLoopAnim}>{children}</Animated.View>

--- a/src/elements/ToolTip/ToolTip.tests.tsx
+++ b/src/elements/ToolTip/ToolTip.tests.tsx
@@ -1,3 +1,4 @@
+import { screen } from "@testing-library/react-native"
 import { ToolTip } from "./ToolTip"
 import { ScreenDimensionsProvider } from "../../utils/hooks"
 import { renderWithWrappers } from "../../utils/tests/renderWithWrappers"
@@ -5,23 +6,23 @@ import { Text } from "../Text"
 
 describe("ToolTip", () => {
   it("shows the flyout when enabled", () => {
-    const { queryByTestId } = renderWithWrappers(
+    renderWithWrappers(
       <ScreenDimensionsProvider>
         <ToolTip enabled testID="flyout" initialToolTipText="Words">
           <Text>Text</Text>
         </ToolTip>
       </ScreenDimensionsProvider>
     )
-    expect(queryByTestId("flyout")).not.toBeNull()
+    expect(screen.getByTestId("flyout")).toBeOnTheScreen()
   })
   it("Does not show the flyout when disabled", () => {
-    const { queryByTestId } = renderWithWrappers(
+    renderWithWrappers(
       <ScreenDimensionsProvider>
         <ToolTip enabled={false} testID="flyout" initialToolTipText="Words">
           <Text>Text</Text>
         </ToolTip>
       </ScreenDimensionsProvider>
     )
-    expect(queryByTestId("flyout")).toBeNull()
+    expect(screen.queryByTestId("flyout")).not.toBeOnTheScreen()
   })
 })

--- a/src/elements/ToolTip/ToolTipFlyout.tsx
+++ b/src/elements/ToolTip/ToolTipFlyout.tsx
@@ -32,10 +32,10 @@ export const ToolTipFlyout: React.FC<Props> = ({
 
   const animationStyle = useAnimatedStyle(() => {
     return {
-      height: withTiming(boxDimensions.value.height, {
+      height: withTiming(boxDimensions.get().height, {
         duration: 500,
       }),
-      width: withTiming(boxDimensions.value.width, {
+      width: withTiming(boxDimensions.get().width, {
         duration: 500,
       }),
     }
@@ -43,12 +43,12 @@ export const ToolTipFlyout: React.FC<Props> = ({
 
   useEffect(() => {
     if (text) {
-      boxDimensions.value = {
+      boxDimensions.set(() => ({
         height,
         width,
-      }
+      }))
     } else {
-      boxDimensions.value = initialBoxDimensions
+      boxDimensions.set(() => initialBoxDimensions)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [text, height, width])

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -1,5 +1,6 @@
 // @ts-expect-error
 global.__TEST__ = true
+import "@testing-library/react-native/extend-expect"
 
 import mockSafeAreaContext from "react-native-safe-area-context/jest/mock"
 jest.mock("react-native-safe-area-context", () => mockSafeAreaContext)

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -7,6 +7,3 @@ jest.mock("react-native-safe-area-context", () => mockSafeAreaContext)
 jest.mock("react-native/Libraries/Animated/NativeAnimatedHelper")
 
 require("react-native-reanimated").setUpTests()
-// @ts-expect-error
-global.__reanimatedWorkletInit = () => {}
-jest.mock("react-native-reanimated", () => require("react-native-reanimated/mock"))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2753,6 +2753,13 @@
     ts-node "^9"
     tslib "^2"
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz#d1145bf2c20132d6400495d6df4bf59362fd9d56"
+  integrity sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
+
 "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -4617,6 +4624,14 @@
     "@typescript-eslint/types" "5.54.1"
     "@typescript-eslint/visitor-keys" "5.54.1"
 
+"@typescript-eslint/scope-manager@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz#d9457ccc6a0b8d6b37d0eb252a23022478c5460c"
+  integrity sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==
+  dependencies:
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/visitor-keys" "5.62.0"
+
 "@typescript-eslint/scope-manager@7.18.0":
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz#c928e7a9fc2c0b3ed92ab3112c614d6bd9951c83"
@@ -4659,6 +4674,11 @@
   version "5.54.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.54.1.tgz#29fbac29a716d0f08c62fe5de70c9b6735de215c"
   integrity sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==
+
+"@typescript-eslint/types@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
+  integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
 
 "@typescript-eslint/types@7.18.0":
   version "7.18.0"
@@ -4704,6 +4724,19 @@
     semver "^7.3.7"
     tsutils "^3.21.0"
 
+"@typescript-eslint/typescript-estree@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz#7d17794b77fabcac615d6a48fb143330d962eb9b"
+  integrity sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==
+  dependencies:
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/visitor-keys" "5.62.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
 "@typescript-eslint/typescript-estree@7.18.0":
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz#b5868d486c51ce8f312309ba79bdb9f331b37931"
@@ -4742,7 +4775,7 @@
     "@typescript-eslint/types" "7.18.0"
     "@typescript-eslint/typescript-estree" "7.18.0"
 
-"@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.43.0":
+"@typescript-eslint/utils@^5.10.0":
   version "5.54.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.54.1.tgz#7a3ee47409285387b9d4609ea7e1020d1797ec34"
   integrity sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==
@@ -4770,6 +4803,20 @@
     eslint-utils "^3.0.0"
     semver "^7.3.7"
 
+"@typescript-eslint/utils@^5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
+  integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/typescript-estree" "5.62.0"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
+
 "@typescript-eslint/visitor-keys@5.47.0":
   version "5.47.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.0.tgz#4aca4efbdf6209c154df1f7599852d571b80bb45"
@@ -4792,6 +4839,14 @@
   integrity sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==
   dependencies:
     "@typescript-eslint/types" "5.54.1"
+    eslint-visitor-keys "^3.3.0"
+
+"@typescript-eslint/visitor-keys@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz#2174011917ce582875954ffe2f6912d5931e353e"
+  integrity sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==
+  dependencies:
+    "@typescript-eslint/types" "5.62.0"
     eslint-visitor-keys "^3.3.0"
 
 "@typescript-eslint/visitor-keys@7.18.0":
@@ -6981,12 +7036,12 @@ eslint-plugin-storybook@0.6.10:
     requireindex "^1.1.0"
     ts-dedent "^2.2.0"
 
-eslint-plugin-testing-library@^5.10.2:
-  version "5.10.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.10.2.tgz#12f231ad9b52b6aef45c801fd00aa129a932e0c2"
-  integrity sha512-f1DmDWcz5SDM+IpCkEX0lbFqrrTs8HRsEElzDEqN/EBI0hpRj8Cns5+IVANXswE8/LeybIJqPAOQIFu2j5Y5sw==
+eslint-plugin-testing-library@6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.4.0.tgz#1ba8a7422e3e31cc315a73ff17c34908f56f9838"
+  integrity sha512-yeWF+YgCgvNyPNI9UKnG0FjeE2sk93N/3lsKqcmR8dSfeXJwFT5irnWo7NjLf152HkRzfoFjh3LsBUrhvFz4eA==
   dependencies:
-    "@typescript-eslint/utils" "^5.43.0"
+    "@typescript-eslint/utils" "^5.62.0"
 
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
This PR resolves [PHIRE-1347] <!-- eg [PROJECT-XXXX] -->

### Description

After upgrading reanimated we noticed a bunch of new warnings coming up.

They pointed to a missuse of `useSharedValue`, as seen [here](https://docs.swmansion.com/react-native-reanimated/docs/core/useSharedValue/#react-compiler-support) we need to avoid accessing the `.value` directly and also mutating values directly `.value = "whatever"`.

Instead we should use the getters and setters as pointed in the PR below.

Nothing changes in the functionality of the animations.


Some other bonus stuff:

properly enabled the `eslint-plugin-testing-library` that wasn't working properly before, and fixed some test issues.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[PHIRE-1347]: https://artsyproduct.atlassian.net/browse/PHIRE-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ