### PR TITLE
chore: increase hitslop of search icon

### DIFF
--- a/src/elements/SearchInput/RoundSearchInput.tsx
+++ b/src/elements/SearchInput/RoundSearchInput.tsx
@@ -2,6 +2,7 @@ import isArray from "lodash/isArray"
 import isString from "lodash/isString"
 import { useCallback, useRef, useState } from "react"
 import { TextInput, TextInputProps } from "react-native"
+import { DEFAULT_HIT_SLOP } from "../../constants"
 import { ArrowLeftIcon, MagnifyingGlassIcon } from "../../svgs"
 import { useColor, useTheme } from "../../utils/hooks"
 import { Flex } from "../Flex"
@@ -165,6 +166,7 @@ export const RoundSearchInput: React.FC<RoundSearchInputProps> = ({
             setIsFocused(false)
             onLeftIconPress?.()
           }}
+          hitSlop={DEFAULT_HIT_SLOP}
           haptic="impactLight"
         >
           {!isFocused ? (


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR increases the `hitslop` of the `RoundSearchIcon` to make it easier to tap.


| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/7b3fda79-f18f-45e8-a39d-02a0d9b21133" /> | <img src="https://github.com/user-attachments/assets/138f4d54-cf3d-4aa2-b1ee-6febfcaf1a91" /> | 


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
