### PR TITLE
chore: use isTestEnvironment instead of __test__

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-global.__TEST__ = false
-
 import { AppRegistry } from "react-native"
 import { App } from "./app/App"
 import { name as appName } from "./app.json"

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -1,7 +1,5 @@
 declare module "" {
-  global {
-    const __TEST__: boolean
-  }
+  global {}
 }
 
 declare function assertNever(val: never): void

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -8,6 +8,7 @@ import { animated, Spring } from "react-spring/renderprops-native"
 import styled from "styled-components/native"
 import { Color, SpacingUnit } from "../../types"
 import { useColor } from "../../utils/hooks"
+import { isTestEnvironment } from "../../utils/tests/isTestEnvironment"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex/Flex"
 import { MeasuredView, ViewMeasurements } from "../MeasuredView"
@@ -192,7 +193,7 @@ export const Button: React.FC<ButtonProps> = ({
                       This will result in us being able to use getByText over
                       getAllByText()[0] to select the buttons in the test environment.
                   */}
-                  {!__TEST__ && longestText && (
+                  {!isTestEnvironment() && longestText && (
                     <MeasuredView setMeasuredState={setLongestTextMeasurements}>
                       <Text color="red" style={textStyle}>
                         {longestText ? longestText : children}

--- a/src/elements/MeasuredView/MeasuredView.tsx
+++ b/src/elements/MeasuredView/MeasuredView.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react"
 import { ViewStyle, LayoutChangeEvent, useWindowDimensions } from "react-native"
+import { isTestEnvironment } from "../../utils/tests/isTestEnvironment"
 import { Box } from "../Box"
 
 export interface ViewMeasurements {
@@ -25,7 +26,7 @@ export const MeasuredView = ({ children, setMeasuredState, show }: Props) => {
     setMeasuredState(event.nativeEvent.layout)
   }, [])
 
-  if (__TEST__) return null
+  if (isTestEnvironment()) return null
 
   return (
     <Box

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -1,5 +1,3 @@
-// @ts-expect-error
-global.__TEST__ = true
 import "@testing-library/react-native/extend-expect"
 
 import mockSafeAreaContext from "react-native-safe-area-context/jest/mock"

--- a/src/utils/hooks/useTheme.tsx
+++ b/src/utils/hooks/useTheme.tsx
@@ -3,6 +3,7 @@ import { useContext } from "react"
 import { ThemeContext } from "styled-components/native"
 import { AllThemesType, THEMES, ThemeType, ThemeWithDarkModeType } from "../../tokens"
 import { Color, ColorDSValue } from "../../types"
+import { isTestEnvironment } from "../tests/isTestEnvironment"
 
 export const useTheme = (): {
   theme: ThemeType | ThemeWithDarkModeType
@@ -14,7 +15,7 @@ export const useTheme = (): {
   // if we are not wrapped in `<Theme>`, if we dev, throw error.
   // if we are in prod, we will default to v2 to avoid a crash.
   // if we are wrapped, then all good.
-  if ((__DEV__ || __TEST__) && maybeTheme === undefined) {
+  if ((__DEV__ || isTestEnvironment()) && maybeTheme === undefined) {
     console.error(
       "You are trying to use the `Theme` context but you have not wrapped your component/screen with `<Theme>`. Please wrap and try again."
     )

--- a/src/utils/tests/isTestEnvironment.ts
+++ b/src/utils/tests/isTestEnvironment.ts
@@ -1,0 +1,3 @@
+export const isTestEnvironment = () => {
+  return !!process.env.JEST_WORKER_ID
+}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR updates Palette to use `isTestingEnvironment()` instead of `__TEST__`. This is required for the Expo migration. 

This will be working for both Eigen and Energy so it shouldn't break anything

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
