### PR TITLE
feat: allow VisualClue color to be customized

### DIFF
--- a/src/elements/VisualClue/VisualClue.stories.tsx
+++ b/src/elements/VisualClue/VisualClue.stories.tsx
@@ -1,11 +1,53 @@
 import { storiesOf } from "@storybook/react-native"
 import { VisualClueDot, VisualClueText } from "./"
 import { List } from "../../storybook/helpers"
+import { Box } from "../Box"
 import { Text } from "../Text"
 
 storiesOf("Theme/Text", module).add("Visual Clue", () => (
   <List>
-    <VisualClueDot />
+    <Box>
+      <Text>Default</Text>
+      <Box position="absolute" top="4px" right="-8px">
+        <VisualClueDot />
+      </Box>
+    </Box>
+
+    <Box>
+      <Text>Diameter: 4</Text>
+      <Box position="absolute" top="4px" right="-4px">
+        <VisualClueDot diameter={4} />
+      </Box>
+    </Box>
+
+    <Box>
+      <Text>Diameter: 8</Text>
+      <Box position="absolute" top="4px" right="-10px">
+        <VisualClueDot diameter={8} />
+      </Box>
+    </Box>
+
+    <Box>
+      <Text>Color: red50</Text>
+      <Box position="absolute" top="4px" right="-8px">
+        <VisualClueDot color="red50" />
+      </Box>
+    </Box>
+
+    <Box>
+      <Text>Color: red100</Text>
+      <Box position="absolute" top="4px" right="-8px">
+        <VisualClueDot color="red100" />
+      </Box>
+    </Box>
+
+    <Box>
+      <Text>Color: black60</Text>
+      <Box position="absolute" top="4px" right="-8px">
+        <VisualClueDot color="black60" />
+      </Box>
+    </Box>
+
     <>
       <Text>A Feature</Text>
       <VisualClueText style={{ top: 14, right: -24 }} />

--- a/src/elements/VisualClue/VisualClueDot.tsx
+++ b/src/elements/VisualClue/VisualClueDot.tsx
@@ -1,16 +1,23 @@
 import { StyleProp, ViewStyle } from "react-native"
+import { Color } from "../../types"
 import { useColor } from "../../utils/hooks/useColor"
 import { Flex } from "../Flex"
 
 const DOT_DIAMETER = 6
+const FILL_COLOR: Color = "blue100"
 
 interface VisualClueDotProps {
   diameter?: number
+  color?: Color
   style?: StyleProp<ViewStyle>
 }
 
-export const VisualClueDot: React.FC<VisualClueDotProps> = ({ diameter = DOT_DIAMETER, style }) => {
-  const color = useColor()
+export const VisualClueDot: React.FC<VisualClueDotProps> = ({
+  diameter = DOT_DIAMETER,
+  color = FILL_COLOR,
+  style,
+}) => {
+  const colors = useColor()
 
   return (
     <Flex
@@ -18,7 +25,7 @@ export const VisualClueDot: React.FC<VisualClueDotProps> = ({ diameter = DOT_DIA
         height: diameter,
         minWidth: diameter,
         borderRadius: diameter / 2,
-        backgroundColor: color("blue100"),
+        backgroundColor: colors(color),
         ...(style as object),
       }}
     />

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,9 +24,9 @@
   integrity sha512-6zGlvqELl4XhqMajJxfgHaY3m5YhZK5FwkxlouJKSb0Su301bzXaPUxKjzj9X147YHJUyrRLSAruzVtj1Gr42Q==
 
 "@artsy/palette-tokens@^6.0.3":
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/@artsy/palette-tokens/-/palette-tokens-6.0.3.tgz#48b5854039e7f494fdef75e2d84682447f447f2d"
-  integrity sha512-Iuq3hjvx6O2d1glmuoo1kFnMLOBJFW2OuQ4Q5fXS1Q/DMAvjwrBmmzZE6HVzwR5BwX5Xy6knRiD8FuPrldeo0Q==
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette-tokens/-/palette-tokens-6.2.0.tgz#189d6dcf8280407c38bfe0fef5153b6b112c70da"
+  integrity sha512-cKsVAO+6Ze78us49yh/VxJ7NmkggPnaPajj0qom3DkxqaTrbJrrWWWtAZkkcMs+3wG3FdI9P2Ro/2XHBUhbnkw==
 
 "@auto-it/all-contributors@10.46.0":
   version "10.46.0"


### PR DESCRIPTION
> [!NOTE]
>
> This depends on the updated tokens from https://github.com/artsy/palette/pull/1415

This PR resolves [ONYX-1463] 

### Description

In order to run an experiment with visual indicator colors, we need to be able pass in a custom color to the `VisualClue` component

The accompanying story now documents the customizable colors and (already) customizable diameters for this component:

<img width=200 src="https://github.com/user-attachments/assets/113ffb1a-1467-468b-b491-a78722607385" />


[ONYX-1463]: https://artsyproduct.atlassian.net/browse/ONYX-1463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ