### PR TITLE
feat(ONYX-1459): add bottom icon position and dark variant to message component 

### DIFF
--- a/src/elements/Message/Message.stories.tsx
+++ b/src/elements/Message/Message.stories.tsx
@@ -3,6 +3,8 @@ import { Text } from "react-native"
 import { Message } from "./Message"
 import { withTheme } from "../../storybook/decorators"
 import { List } from "../../storybook/helpers"
+import { InfoCircleIcon } from "../../svgs"
+import { Button } from "../Button"
 
 storiesOf("Message", module)
   .addDecorator(withTheme)
@@ -41,5 +43,34 @@ storiesOf("Message", module)
       <Message variant="success" showCloseButton title="Success" text="Text" />
       <Message variant="warning" showCloseButton title="Warning" text="Text" />
       <Message variant="error" showCloseButton title="Error" text="Text" />
+    </List>
+  ))
+  .add("IconComponent position", () => (
+    <List contentContainerStyle={{ marginHorizontal: 20, alignItems: "stretch" }}>
+      <Message
+        variant="default"
+        showCloseButton
+        title="Default position"
+        text="Text"
+        IconComponent={() => <InfoCircleIcon />}
+      />
+      <Message
+        iconPosition="right"
+        variant="default"
+        showCloseButton
+        title="Rign"
+        text="Text"
+        IconComponent={() => <Button size="small">Click</Button>}
+      />
+      <Message
+        iconPosition="bottom"
+        variant="default"
+        showCloseButton
+        title="Bottom"
+        text="Text"
+        IconComponent={() => {
+          return <Button size="small">Click</Button>
+        }}
+      />
     </List>
   ))

--- a/src/elements/Message/Message.stories.tsx
+++ b/src/elements/Message/Message.stories.tsx
@@ -43,6 +43,7 @@ storiesOf("Message", module)
       <Message variant="success" showCloseButton title="Success" text="Text" />
       <Message variant="warning" showCloseButton title="Warning" text="Text" />
       <Message variant="error" showCloseButton title="Error" text="Text" />
+      <Message variant="dark" showCloseButton title="Error" text="Text" />
     </List>
   ))
   .add("IconComponent position", () => (
@@ -70,6 +71,20 @@ storiesOf("Message", module)
         text="Text"
         IconComponent={() => {
           return <Button size="small">Click</Button>
+        }}
+      />
+      <Message
+        iconPosition="bottom"
+        variant="dark"
+        showCloseButton
+        title="Bottom, dark"
+        text="Text"
+        IconComponent={() => {
+          return (
+            <Button variant="fillLight" size="small">
+              Click
+            </Button>
+          )
         }}
       />
     </List>

--- a/src/elements/Message/Message.stories.tsx
+++ b/src/elements/Message/Message.stories.tsx
@@ -81,7 +81,7 @@ storiesOf("Message", module)
         text="Text"
         IconComponent={() => {
           return (
-            <Button variant="fillLight" size="small">
+            <Button variant="outlineLight" size="small">
               Click
             </Button>
           )

--- a/src/elements/Message/Message.tests.tsx
+++ b/src/elements/Message/Message.tests.tsx
@@ -32,4 +32,56 @@ describe("Message", () => {
 
     expect(onClose).toHaveBeenCalled()
   })
+
+  it("shows icon component when IconComponent left", () => {
+    renderWithWrappers(
+      <Message
+        variant="default"
+        title="title"
+        text="text"
+        showCloseButton
+        IconComponent={() => <></>}
+      />
+    )
+
+    expect(screen.getByTestId("icon-component-left")).toBeOnTheScreen()
+  })
+
+  it("shows icon component when IconComponent right", () => {
+    renderWithWrappers(
+      <Message
+        iconPosition="right"
+        variant="default"
+        title="title"
+        text="text"
+        showCloseButton
+        IconComponent={() => <></>}
+      />
+    )
+
+    expect(screen.getByTestId("icon-component-right")).toBeOnTheScreen()
+  })
+
+  it("shows icon component when IconComponent bottom", () => {
+    renderWithWrappers(
+      <Message
+        iconPosition="bottom"
+        variant="default"
+        title="title"
+        text="text"
+        showCloseButton
+        IconComponent={() => <></>}
+      />
+    )
+
+    expect(screen.getByTestId("icon-component-bottom")).toBeOnTheScreen()
+  })
+
+  it("does not show icon component when !IconComponent ", () => {
+    renderWithWrappers(<Message variant="default" title="title" text="text" showCloseButton />)
+
+    expect(screen.queryByTestId("icon-component-left")).not.toBeOnTheScreen()
+    expect(screen.queryByTestId("icon-component-right")).not.toBeOnTheScreen()
+    expect(screen.queryByTestId("icon-component-bottom")).not.toBeOnTheScreen()
+  })
 })

--- a/src/elements/Message/Message.tsx
+++ b/src/elements/Message/Message.tsx
@@ -12,7 +12,7 @@ export interface MessageProps {
   bodyTextStyle?: TextProps
   containerStyle?: FlexProps
   IconComponent?: React.FC<any>
-  iconPosition?: "left" | "right"
+  iconPosition?: "left" | "right" | "bottom"
   onClose?: () => void
   showCloseButton?: boolean
   testID?: string
@@ -70,12 +70,12 @@ export const Message: React.FC<MessageProps> = ({
         ],
       }}
     >
-      <Flex backgroundColor={color(colors[variant].background)} {...containerStyle}>
-        <Flex px={2} py={1} flexDirection="row" justifyContent="space-between">
+      <Flex px={2} backgroundColor={color(colors[variant].background)} {...containerStyle}>
+        <Flex py={1} flexDirection="row" justifyContent="space-between">
           <Flex flex={1}>
             <Flex flexDirection="row">
               {!!IconComponent && iconPosition === "left" && (
-                <Flex mr={1}>
+                <Flex mr={1} testID="icon-component-left">
                   <IconComponent />
                 </Flex>
               )}
@@ -94,7 +94,11 @@ export const Message: React.FC<MessageProps> = ({
           </Flex>
 
           {!!IconComponent && iconPosition === "right" && (
-            <Flex mr={showCloseButton ? 1 : 0} justifyContent="center">
+            <Flex
+              mr={showCloseButton ? 1 : 0}
+              justifyContent="center"
+              testID="icon-component-right"
+            >
               <IconComponent />
             </Flex>
           )}
@@ -111,6 +115,12 @@ export const Message: React.FC<MessageProps> = ({
             </Flex>
           )}
         </Flex>
+
+        {!!IconComponent && iconPosition === "bottom" && (
+          <Flex mb={1} justifyContent="center" testID="icon-component-bottom">
+            <IconComponent />
+          </Flex>
+        )}
       </Flex>
     </Animated.View>
   )

--- a/src/elements/Message/Message.tsx
+++ b/src/elements/Message/Message.tsx
@@ -6,7 +6,7 @@ import { useColor } from "../../utils/hooks/useColor"
 import { Flex, FlexProps } from "../Flex"
 import { Text, TextProps } from "../Text"
 
-type MessageVariant = "default" | "info" | "success" | "alert" | "warning" | "error"
+type MessageVariant = "default" | "info" | "success" | "alert" | "warning" | "error" | "dark"
 
 export interface MessageProps {
   bodyTextStyle?: TextProps
@@ -110,7 +110,7 @@ export const Message: React.FC<MessageProps> = ({
                 onPress={handleClose}
                 hitSlop={{ bottom: 10, right: 10, left: 10, top: 10 }}
               >
-                <CloseIcon fill={color("black100")} />
+                <CloseIcon fill={colors[variant].icon} />
               </TouchableOpacity>
             </Flex>
           )}
@@ -126,35 +126,50 @@ export const Message: React.FC<MessageProps> = ({
   )
 }
 
-const colors: Record<MessageVariant, { background: Color; title: Color; text: Color }> = {
+const colors: Record<
+  MessageVariant,
+  { background: Color; title: Color; text: Color; icon?: Color }
+> = {
   default: {
     background: "black5",
     title: "black100",
     text: "black60",
+    icon: "black100",
   },
   info: {
     background: "blue10",
     title: "blue100",
     text: "black100",
+    icon: "black100",
   },
   success: {
     background: "green10",
     title: "green150",
     text: "black100",
+    icon: "black100",
   },
   alert: {
     background: "orange10",
     title: "orange150",
     text: "black100",
+    icon: "black100",
   },
   warning: {
     background: "yellow10",
     title: "yellow150",
     text: "black100",
+    icon: "black100",
   },
   error: {
     background: "red10",
     title: "red100",
     text: "black100",
+    icon: "black100",
+  },
+  dark: {
+    background: "black100",
+    title: "white100",
+    text: "white100",
+    icon: "white100",
   },
 }


### PR DESCRIPTION
This PR resolves [ONYX-1459] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
As per design, add a new icon position to the message component - bottom
In addition, add dark message variant
<image src="https://github.com/user-attachments/assets/b9b5d90c-2951-4107-b3e5-f4dcfd88308d" width="250" />




[ONYX-1459]: https://artsyproduct.atlassian.net/browse/ONYX-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ