### PR TITLE
feat: add link pill variant

### DIFF
--- a/src/elements/Pill/Pill.stories.tsx
+++ b/src/elements/Pill/Pill.stories.tsx
@@ -118,5 +118,12 @@ storiesOf("Pill", module)
       </List>
     )
   })
+  .add("Link", () => {
+    return (
+      <List contentContainerStyle={{ marginHorizontal: 20 }}>
+        <Pill variant="link">Yes, I love collecting art</Pill>
+      </List>
+    )
+  })
 
 const src = "https://d32dm0rphc51dk.cloudfront.net/A983VUIZusVBKy420xP3ow/normalized.jpg"

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -17,9 +17,10 @@ export const PILL_VARIANT_NAMES = [
   "profile",
   "search",
   "onboarding",
+  "link",
 ] as const
 export type PillState = "default" | "selected" | "disabled"
-export type PillVariant = typeof PILL_VARIANT_NAMES[number]
+export type PillVariant = (typeof PILL_VARIANT_NAMES)[number]
 
 export type PillProps = (FlexProps & {
   selected?: boolean
@@ -29,10 +30,7 @@ export type PillProps = (FlexProps & {
 }) &
   (
     | {
-        variant?: Extract<
-          PillVariant,
-          "default" | "filter" | "badge" | "search" | "dotted" | "onboarding"
-        >
+        variant?: Extract<PillVariant, keyof typeof PILL_VARIANTS>
         src?: never
       }
     | { variant: Extract<PillVariant, "profile">; src?: string }
@@ -197,6 +195,14 @@ const PILL_VARIANTS: Record<PillVariant, Record<PillState, FlattenInterpolation<
       border-color: ${themeGet("colors.black60")};
     `,
   },
+  link: {
+    ...PILL_STATES,
+    default: css`
+      ${PILL_STATES.default}
+      border-color: ${themeGet("colors.black5")};
+      background-color: ${themeGet("colors.black5")};
+    `,
+  },
 }
 
 const defaultColors: Record<PillState, Color> = {
@@ -225,4 +231,5 @@ const TEXT_COLOR: Record<PillVariant, Record<PillState, Color>> = {
     ...defaultColors,
     disabled: "black100",
   },
+  link: defaultColors,
 }


### PR DESCRIPTION
This PR resolves [ONYX-1482] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds a new variant called `link` to the Pill component.

Link to the conversation over Figma: https://www.figma.com/design/Z9legdjhKORHt0vOGpvBg3?node-id=268-49788&m=dev#1087158211

![Group 33](https://github.com/user-attachments/assets/8444caba-4a07-4d89-9d20-e78b2caa638e)


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[ONYX-1482]: https://artsyproduct.atlassian.net/browse/ONYX-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ