### PR TITLE
fix: dark-mode for inputs

### DIFF
--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -7,7 +7,6 @@ import isString from "lodash/isString"
 import {
   RefObject,
   forwardRef,
-  memo,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -28,11 +27,11 @@ import {
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated"
 import styled from "styled-components"
 import {
-  getInputVariants,
   InputState,
   InputVariant,
   getInputState,
   getInputVariant,
+  getInputVariants,
 } from "./helpers"
 import { maskValue, unmaskText } from "./maskValue"
 import { EyeClosedIcon, EyeOpenedIcon, TriangleDown, XCircleIcon } from "../../svgs"
@@ -133,621 +132,612 @@ export interface InputRef {
   clear: () => void
 }
 
-export const Input = memo(
-  forwardRef<InputRef, InputProps>(
-    (
-      {
-        addClearListener = false,
-        defaultValue,
-        disabled = false,
-        enableClearButton = false,
-        fixedRightPlaceholder,
-        hintText = "What's this?",
-        icon,
-        leftComponentWidth = LEFT_COMPONENT_WIDTH,
-        mask,
-        selectComponentWidth = SELECT_COMPONENT_WIDTH,
-        loading = false,
-        onBlur,
-        onChangeText,
-        onClear,
-        onFocus,
-        onSelectTap,
-        placeholder,
-        secureTextEntry = false,
-        style: styleProp = {},
-        unit,
-        value: propValue,
-        selectDisplayLabel,
-        ...props
-      },
-      ref
-    ) => {
-      const { color, theme, space } = useTheme()
+export const Input = forwardRef<InputRef, InputProps>(
+  (
+    {
+      addClearListener = false,
+      defaultValue,
+      disabled = false,
+      enableClearButton = false,
+      fixedRightPlaceholder,
+      hintText = "What's this?",
+      icon,
+      leftComponentWidth = LEFT_COMPONENT_WIDTH,
+      mask,
+      selectComponentWidth = SELECT_COMPONENT_WIDTH,
+      loading = false,
+      onBlur,
+      onChangeText,
+      onClear,
+      onFocus,
+      onSelectTap,
+      placeholder,
+      secureTextEntry = false,
+      style: styleProp = {},
+      unit,
+      value: propValue,
+      selectDisplayLabel,
+      ...props
+    },
+    ref
+  ) => {
+    const { color, theme, space } = useTheme()
 
-      const [focused, setIsFocused] = useState(false)
-      const [delayedFocused, setDelayedFocused] = useState(false)
+    const [focused, setIsFocused] = useState(false)
+    const [delayedFocused, setDelayedFocused] = useState(false)
 
-      const [value, setValue] = useState(
-        maskValue({
-          currentValue: propValue ?? defaultValue,
-          mask: mask,
-        })
-      )
-
-      const [showPassword, setShowPassword] = useState(!secureTextEntry)
-
-      const [inputWidth, setInputWidth] = useState(0)
-      const placeholderWidths = useRef<number[]>([])
-
-      const rightComponentRef = useRef(null)
-      const inputRef = useRef<TextInput>()
-
-      const variant: InputVariant = getInputVariant({
-        hasError: !!props.error,
-        disabled: disabled,
+    const [value, setValue] = useState(
+      maskValue({
+        currentValue: propValue ?? defaultValue,
+        mask: mask,
       })
+    )
 
-      const hasLeftComponent = useMemo(
-        () => !!unit || !!icon || !!onSelectTap,
-        [unit, icon, onSelectTap]
-      )
+    const [showPassword, setShowPassword] = useState(!secureTextEntry)
 
-      const animatedState = useSharedValue<InputState>(
-        getInputState({
-          isFocused: !!focused,
-          value: value,
-        })
-      )
+    const [inputWidth, setInputWidth] = useState(0)
+    const placeholderWidths = useRef<number[]>([])
 
-      useImperativeHandle(ref, () => inputRef.current as InputRef)
+    const rightComponentRef = useRef(null)
+    const inputRef = useRef<TextInput>()
 
-      useEffect(() => {
-        // If the prop value changes, update the local state
-        // This optimisation is not needed if no propValue has been specified
-        if (propValue !== undefined && propValue !== value) {
-          setValue(maskValue({ currentValue: propValue || "", mask }))
-        }
-      }, [propValue, value, mask])
+    const variant: InputVariant = getInputVariant({
+      hasError: !!props.error,
+      disabled: disabled,
+    })
 
-      useEffect(() => {
-        // If the mask value changes, update the value state to be formatted again
-        setValue(maskValue({ currentValue: value, mask }))
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-      }, [mask])
+    const hasLeftComponent = useMemo(
+      () => !!unit || !!icon || !!onSelectTap,
+      [unit, icon, onSelectTap]
+    )
 
-      const fontFamily = theme.fonts.sans.regular
+    const animatedState = useSharedValue<InputState>(
+      getInputState({
+        isFocused: !!focused,
+        value: value,
+      })
+    )
 
-      useEffect(() => {
-        /* to make the font work for secure text inputs,
+    useImperativeHandle(ref, () => inputRef.current as InputRef)
+
+    useEffect(() => {
+      // If the prop value changes, update the local state
+      // This optimisation is not needed if no propValue has been specified
+      if (propValue !== undefined && propValue !== value) {
+        setValue(maskValue({ currentValue: propValue || "", mask }))
+      }
+    }, [propValue, value, mask])
+
+    useEffect(() => {
+      // If the mask value changes, update the value state to be formatted again
+      setValue(maskValue({ currentValue: value, mask }))
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [mask])
+
+    const fontFamily = theme.fonts.sans.regular
+
+    useEffect(() => {
+      /* to make the font work for secure text inputs,
       see https://github.com/facebook/react-native/issues/30123#issuecomment-711076098 */
-        inputRef.current?.setNativeProps({
-          style: { fontFamily },
-        })
-      }, [fontFamily])
-
-      useEffect(() => {
-        // We don't need to delay hiding the placeholder
-        if (!focused && delayedFocused) {
-          setDelayedFocused(false)
-        }
-
-        let delayFocusedTimeout: NodeJS.Timeout
-
-        // We only want to show the placeholder after we're sure the title animation has finished
-        if (!delayedFocused && focused) {
-          delayFocusedTimeout = setTimeout(() => {
-            setDelayedFocused(focused)
-          }, 200)
-        }
-
-        return () => {
-          if (delayFocusedTimeout) {
-            clearTimeout(delayFocusedTimeout)
-          }
-        }
-      }, [focused, delayedFocused])
-
-      const handleChangeText = useCallback(
-        (text: string) => {
-          if (mask) {
-            const newText =
-              maskValue({ currentValue: text, mask: mask, previousValue: value }) || ""
-            setValue(newText)
-            onChangeText?.(newText, unmaskText(text))
-          } else {
-            setValue(text)
-            onChangeText?.(text)
-          }
-        },
-        [onChangeText, value, mask]
-      )
-
-      const handleClear = useCallback(() => {
-        LayoutAnimation.configureNext({ ...LayoutAnimation.Presets.easeInEaseOut, duration: 200 })
-        inputRef.current?.clear()
-        handleChangeText("")
-        onClear?.()
-      }, [onClear, handleChangeText])
-
-      useEffect(() => {
-        if (!addClearListener) {
-          return
-        }
-
-        inputEvents.addListener("clear", handleClear)
-
-        return () => {
-          inputEvents.removeListener("clear", handleClear)
-        }
-      }, [addClearListener, handleClear])
-
-      const { width: rightComponentWidth = 0 } = useMeasure({ ref: rightComponentRef })
-
-      const textInputPaddingLeft = useMemo(() => {
-        if (!hasLeftComponent) {
-          return HORIZONTAL_PADDING
-        }
-
-        if (onSelectTap) {
-          return selectComponentWidth + HORIZONTAL_PADDING
-        }
-
-        return leftComponentWidth
-      }, [hasLeftComponent, leftComponentWidth, onSelectTap, selectComponentWidth])
-
-      const styles = useMemo(() => {
-        return {
-          fontFamily: fontFamily,
-          fontSize: parseInt(THEME.textVariants["sm-display"].fontSize, 10),
-          minHeight: props.multiline ? MULTILINE_INPUT_MIN_HEIGHT : INPUT_MIN_HEIGHT,
-          maxHeight: props.multiline ? MULTILINE_INPUT_MAX_HEIGHT : undefined,
-          height: props.multiline ? MULTILINE_INPUT_MIN_HEIGHT : undefined,
-          borderWidth: 1,
-          paddingRight: rightComponentWidth + HORIZONTAL_PADDING,
-          paddingLeft: textInputPaddingLeft,
-          ...(styleProp as {}),
-        }
-      }, [fontFamily, styleProp, props.multiline, rightComponentWidth, textInputPaddingLeft])
-
-      const labelStyles = useMemo(() => {
-        return {
-          // this is neeeded too make sure the label is on top of the input
-          backgroundColor: color("background"),
-          marginRight: space(0.5),
-          zIndex: 100,
-          fontFamily: fontFamily,
-        }
-      }, [fontFamily, space, color])
-
-      const inputVariants = getInputVariants(theme)
-
-      useEffect(() => {
-        const inputState = getInputState({
-          isFocused: !!focused,
-          value: value,
-        })
-        animatedState.set(() => inputState)
-      }, [value, focused, animatedState])
-
-      const textInputAnimatedStyles = useAnimatedStyle(() => {
-        return {
-          borderColor: withTiming(inputVariants[variant][animatedState.get()].inputBorderColor),
-          color: withTiming(inputVariants[variant][animatedState.get()].inputTextColor),
-        }
+      inputRef.current?.setNativeProps({
+        style: { fontFamily },
       })
+    }, [fontFamily])
 
-      const labelAnimatedStyles = useAnimatedStyle(() => {
-        const hasValue = !!value
-
-        // Only add a margin if the input has a left component and it is not focused and has no value
-        const marginLeft =
-          textInputPaddingLeft && !focused && !hasValue
-            ? textInputPaddingLeft - 3
-            : HORIZONTAL_PADDING
-
-        return {
-          color: withTiming(inputVariants[variant][animatedState.get()].labelColor),
-          top: withTiming(inputVariants[variant][animatedState.get()].labelTop),
-          fontSize: withTiming(inputVariants[variant][animatedState.get()].labelFontSize),
-          marginLeft: withTiming(marginLeft),
-        }
-      })
-
-      const selectComponentStyles = useAnimatedStyle(() => {
-        return {
-          borderColor: withTiming(inputVariants[variant][animatedState.get()].inputBorderColor),
-        }
-      })
-
-      const handleFocus = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
-        setIsFocused(true)
-        onFocus?.(e)
+    useEffect(() => {
+      // We don't need to delay hiding the placeholder
+      if (!focused && delayedFocused) {
+        setDelayedFocused(false)
       }
 
-      const handleBlur = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
-        setIsFocused(false)
-        onBlur?.(e)
+      let delayFocusedTimeout: NodeJS.Timeout
+
+      // We only want to show the placeholder after we're sure the title animation has finished
+      if (!delayedFocused && focused) {
+        delayFocusedTimeout = setTimeout(() => {
+          setDelayedFocused(focused)
+        }, 200)
       }
 
-      const hasTitle = !!props.title
-
-      const renderLeftComponent = useCallback(() => {
-        const leftComponentSharedStyles: ViewProps["style"] = {
-          position: "absolute",
-          paddingHorizontal: HORIZONTAL_PADDING,
-          height: INPUT_MIN_HEIGHT,
-          top: hasTitle ? LABEL_HEIGHT : 0,
-          alignItems: "center",
-          zIndex: 100,
+      return () => {
+        if (delayFocusedTimeout) {
+          clearTimeout(delayFocusedTimeout)
         }
+      }
+    }, [focused, delayedFocused])
 
-        if (unit || icon) {
-          return (
-            <Flex
-              style={{
-                ...leftComponentSharedStyles,
-                justifyContent: "center",
-                width: leftComponentWidth,
-              }}
-            >
-              {unit && (
-                <Text color={disabled ? "black30" : "black60"} variant="sm-display">
-                  {unit}
-                </Text>
-              )}
-              {icon}
-            </Flex>
-          )
+    const handleChangeText = useCallback(
+      (text: string) => {
+        if (mask) {
+          const newText = maskValue({ currentValue: text, mask: mask, previousValue: value }) || ""
+          setValue(newText)
+          onChangeText?.(newText, unmaskText(text))
+        } else {
+          setValue(text)
+          onChangeText?.(text)
         }
+      },
+      [onChangeText, value, mask]
+    )
 
-        if (onSelectTap) {
-          return (
-            <TouchableOpacity
-              onPress={onSelectTap}
-              style={[
-                leftComponentSharedStyles,
-                {
-                  width: selectComponentWidth,
-                },
-              ]}
-              hitSlop={{ top: 10, right: 10, bottom: 10, left: 10 }}
-            >
-              <AnimatedFlex
-                style={[
-                  {
-                    paddingHorizontal: HORIZONTAL_PADDING,
-                    height: INPUT_MIN_HEIGHT,
-                    alignItems: "center",
-                    width: selectComponentWidth,
-                    flexDirection: "row",
-                    borderRightWidth: 1,
-                    justifyContent: "space-between",
-                  },
-                  selectComponentStyles,
-                ]}
-              >
-                <Text color={disabled ? "black30" : "black100"}>{selectDisplayLabel}</Text>
-                <TriangleDown fill="black60" width={10} />
-              </AnimatedFlex>
-            </TouchableOpacity>
-          )
-        }
+    const handleClear = useCallback(() => {
+      LayoutAnimation.configureNext({ ...LayoutAnimation.Presets.easeInEaseOut, duration: 200 })
+      inputRef.current?.clear()
+      handleChangeText("")
+      onClear?.()
+    }, [onClear, handleChangeText])
 
-        return null
-      }, [
-        hasTitle,
-        unit,
-        icon,
-        onSelectTap,
-        leftComponentWidth,
-        disabled,
-        selectComponentWidth,
-        selectComponentStyles,
-        selectDisplayLabel,
-      ])
+    useEffect(() => {
+      if (!addClearListener) {
+        return
+      }
 
-      const renderRightComponent = useCallback(() => {
-        if (fixedRightPlaceholder) {
-          return (
-            <Flex
-              justifyContent="center"
-              position="absolute"
-              right={`${HORIZONTAL_PADDING}px`}
-              top={hasTitle ? LABEL_HEIGHT : 0}
-              height={INPUT_MIN_HEIGHT}
-              ref={rightComponentRef}
-            >
-              <Text color={disabled ? "black30" : "black60"}>{fixedRightPlaceholder}</Text>
-            </Flex>
-          )
-        }
+      inputEvents.addListener("clear", handleClear)
 
-        if (loading) {
-          return (
-            <Flex
-              justifyContent="center"
-              position="absolute"
-              right={`${HORIZONTAL_PADDING}px`}
-              top={hasTitle ? LABEL_HEIGHT : 0}
-              height={INPUT_MIN_HEIGHT}
-              ref={rightComponentRef}
-            >
-              <Spinner
-                size="medium"
-                style={{
-                  right: 0,
-                  width: 15,
-                  backgroundColor: color("black60"),
-                }}
-              />
-            </Flex>
-          )
-        }
+      return () => {
+        inputEvents.removeListener("clear", handleClear)
+      }
+    }, [addClearListener, handleClear])
 
-        if (enableClearButton && value) {
-          return (
-            <Flex
-              justifyContent="center"
-              position="absolute"
-              right={`${HORIZONTAL_PADDING}px`}
-              top={hasTitle ? LABEL_HEIGHT : 0}
-              height={INPUT_MIN_HEIGHT}
-              zIndex={100}
-              ref={rightComponentRef}
-            >
-              <Touchable
-                haptic="impactMedium"
-                onPress={handleClear}
-                hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
-                accessibilityLabel="Clear input button"
-                testID="clear-input-button"
-              >
-                <XCircleIcon fill="black30" />
-              </Touchable>
-            </Flex>
-          )
-        }
+    const { width: rightComponentWidth = 0 } = useMeasure({ ref: rightComponentRef })
 
-        if (secureTextEntry) {
-          return (
-            <Flex
-              justifyContent="center"
-              position="absolute"
-              right={`${HORIZONTAL_PADDING}px`}
-              top={hasTitle ? LABEL_HEIGHT : 0}
-              height={INPUT_MIN_HEIGHT}
-              zIndex={100}
-              ref={rightComponentRef}
-            >
-              <Touchable
-                haptic
-                onPress={() => {
-                  LayoutAnimation.configureNext({
-                    ...LayoutAnimation.Presets.easeInEaseOut,
-                    duration: 200,
-                  })
-                  setShowPassword(!showPassword)
-                }}
-                accessibilityLabel={showPassword ? "hide password button" : "show password button"}
-                hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
-              >
-                {!showPassword ? (
-                  <EyeClosedIcon fill="black30" />
-                ) : (
-                  <EyeOpenedIcon fill="black60" />
-                )}
-              </Touchable>
-            </Flex>
-          )
-        }
+    const textInputPaddingLeft = useMemo(() => {
+      if (!hasLeftComponent) {
+        return HORIZONTAL_PADDING
+      }
 
-        return null
-      }, [
-        fixedRightPlaceholder,
-        loading,
-        enableClearButton,
-        value,
-        secureTextEntry,
-        hasTitle,
-        disabled,
-        color,
-        handleClear,
-        showPassword,
-      ])
+      if (onSelectTap) {
+        return selectComponentWidth + HORIZONTAL_PADDING
+      }
 
-      const renderBottomComponent = useCallback(() => {
-        if (!!props.error) {
-          return (
-            <Text color="red100" variant="xs" px={`${HORIZONTAL_PADDING}px`} mt={0.5}>
-              {props.error}
-            </Text>
-          )
-        }
+      return leftComponentWidth
+    }, [hasLeftComponent, leftComponentWidth, onSelectTap, selectComponentWidth])
 
-        return (
-          <Flex flexDirection="row" justifyContent="space-between">
-            {!!props.required || !!props.optional ? (
-              <Text color="black60" variant="xs" pl={`${HORIZONTAL_PADDING}px`} mt={0.5}>
-                {!!props.required && "* Required"}
-                {!!props.optional && "* Optional"}
-              </Text>
-            ) : (
-              // Adding this empty flex to make sure that the maxLength text is always on the right
-              <Flex />
-            )}
-            {!!props.maxLength && !!props.showLimit && (
-              <Text color="black60" variant="xs" pr={`${HORIZONTAL_PADDING}px`} mt={0.5}>
-                {(value || "").length} / {props.maxLength}
-              </Text>
-            )}
-          </Flex>
-        )
-      }, [props.error, props.maxLength, props.optional, props.required, props.showLimit, value])
+    const styles = useMemo(() => {
+      return {
+        fontFamily: fontFamily,
+        fontSize: parseInt(THEME.textVariants["sm-display"].fontSize, 10),
+        minHeight: props.multiline ? MULTILINE_INPUT_MIN_HEIGHT : INPUT_MIN_HEIGHT,
+        maxHeight: props.multiline ? MULTILINE_INPUT_MAX_HEIGHT : undefined,
+        height: props.multiline ? MULTILINE_INPUT_MIN_HEIGHT : undefined,
+        borderWidth: 1,
+        paddingRight: rightComponentWidth + HORIZONTAL_PADDING,
+        paddingLeft: textInputPaddingLeft,
+        ...(styleProp as {}),
+      }
+    }, [fontFamily, styleProp, props.multiline, rightComponentWidth, textInputPaddingLeft])
 
-      const renderHint = useCallback(() => {
-        if (!props.onHintPress) {
-          return null
-        }
+    const labelStyles = useMemo(() => {
+      return {
+        // this is neeeded too make sure the label is on top of the input
+        backgroundColor: color("background"),
+        marginRight: space(0.5),
+        zIndex: 100,
+        fontFamily: fontFamily,
+      }
+    }, [fontFamily, space, color])
 
+    const inputVariants = getInputVariants(theme)
+
+    useEffect(() => {
+      const inputState = getInputState({
+        isFocused: !!focused,
+        value: value,
+      })
+      animatedState.set(() => inputState)
+    }, [value, focused, animatedState])
+
+    const textInputAnimatedStyles = useAnimatedStyle(() => {
+      return {
+        borderColor: withTiming(inputVariants[variant][animatedState.get()].inputBorderColor),
+        color: withTiming(inputVariants[variant][animatedState.get()].inputTextColor),
+      }
+    })
+
+    const labelAnimatedStyles = useAnimatedStyle(() => {
+      const hasValue = !!value
+
+      // Only add a margin if the input has a left component and it is not focused and has no value
+      const marginLeft =
+        textInputPaddingLeft && !focused && !hasValue
+          ? textInputPaddingLeft - 3
+          : HORIZONTAL_PADDING
+
+      return {
+        color: withTiming(inputVariants[variant][animatedState.get()].labelColor),
+        top: withTiming(inputVariants[variant][animatedState.get()].labelTop),
+        fontSize: withTiming(inputVariants[variant][animatedState.get()].labelFontSize),
+        marginLeft: withTiming(marginLeft),
+      }
+    })
+
+    const selectComponentStyles = useAnimatedStyle(() => {
+      return {
+        borderColor: withTiming(inputVariants[variant][animatedState.get()].inputBorderColor),
+      }
+    })
+
+    const handleFocus = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
+      setIsFocused(true)
+      onFocus?.(e)
+    }
+
+    const handleBlur = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
+      setIsFocused(false)
+      onBlur?.(e)
+    }
+
+    const hasTitle = !!props.title
+
+    const renderLeftComponent = useCallback(() => {
+      const leftComponentSharedStyles: ViewProps["style"] = {
+        position: "absolute",
+        paddingHorizontal: HORIZONTAL_PADDING,
+        height: INPUT_MIN_HEIGHT,
+        top: hasTitle ? LABEL_HEIGHT : 0,
+        alignItems: "center",
+        zIndex: 100,
+      }
+
+      if (unit || icon) {
         return (
           <Flex
             style={{
-              alignItems: "flex-end",
-              top: space(2),
+              ...leftComponentSharedStyles,
+              justifyContent: "center",
+              width: leftComponentWidth,
             }}
           >
-            <Touchable
-              onPress={props.onHintPress}
-              haptic="impactLight"
-              hitSlop={{
-                top: 5,
-                right: 10,
-                bottom: 5,
-                left: 10,
-              }}
-            >
-              <Text underline variant="xs" color="black60">
-                {hintText}
+            {unit && (
+              <Text color={disabled ? "black30" : "black60"} variant="sm-display">
+                {unit}
               </Text>
+            )}
+            {icon}
+          </Flex>
+        )
+      }
+
+      if (onSelectTap) {
+        return (
+          <TouchableOpacity
+            onPress={onSelectTap}
+            style={[
+              leftComponentSharedStyles,
+              {
+                width: selectComponentWidth,
+              },
+            ]}
+            hitSlop={{ top: 10, right: 10, bottom: 10, left: 10 }}
+          >
+            <AnimatedFlex
+              style={[
+                {
+                  paddingHorizontal: HORIZONTAL_PADDING,
+                  height: INPUT_MIN_HEIGHT,
+                  alignItems: "center",
+                  width: selectComponentWidth,
+                  flexDirection: "row",
+                  borderRightWidth: 1,
+                  justifyContent: "space-between",
+                },
+                selectComponentStyles,
+              ]}
+            >
+              <Text color={disabled ? "black30" : "black100"}>{selectDisplayLabel}</Text>
+              <TriangleDown fill="black60" width={10} />
+            </AnimatedFlex>
+          </TouchableOpacity>
+        )
+      }
+
+      return null
+    }, [
+      hasTitle,
+      unit,
+      icon,
+      onSelectTap,
+      leftComponentWidth,
+      disabled,
+      selectComponentWidth,
+      selectComponentStyles,
+      selectDisplayLabel,
+    ])
+
+    const renderRightComponent = useCallback(() => {
+      if (fixedRightPlaceholder) {
+        return (
+          <Flex
+            justifyContent="center"
+            position="absolute"
+            right={`${HORIZONTAL_PADDING}px`}
+            top={hasTitle ? LABEL_HEIGHT : 0}
+            height={INPUT_MIN_HEIGHT}
+            ref={rightComponentRef}
+          >
+            <Text color={disabled ? "black30" : "black60"}>{fixedRightPlaceholder}</Text>
+          </Flex>
+        )
+      }
+
+      if (loading) {
+        return (
+          <Flex
+            justifyContent="center"
+            position="absolute"
+            right={`${HORIZONTAL_PADDING}px`}
+            top={hasTitle ? LABEL_HEIGHT : 0}
+            height={INPUT_MIN_HEIGHT}
+            ref={rightComponentRef}
+          >
+            <Spinner
+              size="medium"
+              style={{
+                right: 0,
+                width: 15,
+                backgroundColor: color("black60"),
+              }}
+            />
+          </Flex>
+        )
+      }
+
+      if (enableClearButton && value) {
+        return (
+          <Flex
+            justifyContent="center"
+            position="absolute"
+            right={`${HORIZONTAL_PADDING}px`}
+            top={hasTitle ? LABEL_HEIGHT : 0}
+            height={INPUT_MIN_HEIGHT}
+            zIndex={100}
+            ref={rightComponentRef}
+          >
+            <Touchable
+              haptic="impactMedium"
+              onPress={handleClear}
+              hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
+              accessibilityLabel="Clear input button"
+              testID="clear-input-button"
+            >
+              <XCircleIcon fill="black30" />
             </Touchable>
           </Flex>
         )
-      }, [hintText, props.onHintPress, space])
+      }
 
-      const getPlatformSpecificPlaceholder = useCallback(() => {
-        if (!placeholder) {
-          return ""
-        }
-
-        if (Platform.OS === "ios") {
-          return isArray(placeholder) ? placeholder[0] : placeholder
-        }
-
-        // if it's android and we only have one string, return that string
-        if (isString(placeholder)) {
-          return placeholder
-        }
-        // otherwise, find a placeholder that has longest width that fits in the inputtext
-        const longestFittingStringIndex = placeholderWidths.current.findIndex(
-          (placeholderWidth) => {
-            return placeholderWidth <= inputWidth
-          }
-        )
-        if (longestFittingStringIndex > -1) {
-          return placeholder[longestFittingStringIndex]
-        }
-
-        // otherwise just return the shortest placeholder
-        return placeholder[placeholder.length - 1]
-      }, [inputWidth, placeholder])
-
-      const getPlaceholder = useCallback(() => {
-        // Show placeholder always if there is no title
-        // This is because we won't have a title animation
-        if (!props.title) {
-          return getPlatformSpecificPlaceholder()
-        }
-
-        // On blur, we want to show the placeholder immediately
-        if (delayedFocused) {
-          return getPlatformSpecificPlaceholder()
-        }
-
-        // On focus, we want to show the placeholder after the title animation has finished
-        return ""
-      }, [delayedFocused, getPlatformSpecificPlaceholder, props.title])
-
-      const renderAnimatedTitle = useCallback(() => {
-        if (!props.title) {
-          return null
-        }
-
-        return (
-          <Flex flexDirection="row" zIndex={100} pointerEvents="none" height={LABEL_HEIGHT}>
-            <AnimatedText style={[labelStyles, labelAnimatedStyles]} numberOfLines={1}>
-              {" "}
-              {props.title}{" "}
-            </AnimatedText>
-          </Flex>
-        )
-      }, [labelStyles, labelAnimatedStyles, props.title])
-
-      const renderAndroidPlaceholderMeasuringHack = useCallback(() => {
-        if (Platform.OS === "ios" || !isArray(placeholder)) {
-          return null
-        }
-
-        // Do not render the hack if we have already measured the placeholder
-        if (placeholderWidths.current.length > 0) {
-          return null
-        }
-
+      if (secureTextEntry) {
         return (
           <Flex
-            style={{
-              position: "absolute",
-              top: -10000, // make sure its off the screen
-              width: 10000, // make sure Texts can take as much space as they need
-              alignItems: "baseline", // this is to make Texts get the smallest width they can get to fit the text
-            }}
+            justifyContent="center"
+            position="absolute"
+            right={`${HORIZONTAL_PADDING}px`}
+            top={hasTitle ? LABEL_HEIGHT : 0}
+            height={INPUT_MIN_HEIGHT}
+            zIndex={100}
+            ref={rightComponentRef}
           >
-            {placeholder.map((placeholderString, index) => (
-              <Text
-                onLayout={(event) => {
-                  placeholderWidths.current[index] = event.nativeEvent.layout.width
-                }}
-                numberOfLines={1}
-                style={{
-                  ...styles,
-                }}
-              >
-                {placeholderString}
-              </Text>
-            ))}
+            <Touchable
+              haptic
+              onPress={() => {
+                LayoutAnimation.configureNext({
+                  ...LayoutAnimation.Presets.easeInEaseOut,
+                  duration: 200,
+                })
+                setShowPassword(!showPassword)
+              }}
+              accessibilityLabel={showPassword ? "hide password button" : "show password button"}
+              hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
+            >
+              {!showPassword ? <EyeClosedIcon fill="black30" /> : <EyeOpenedIcon fill="black60" />}
+            </Touchable>
           </Flex>
         )
-      }, [placeholder, styles])
+      }
+
+      return null
+    }, [
+      fixedRightPlaceholder,
+      loading,
+      enableClearButton,
+      value,
+      secureTextEntry,
+      hasTitle,
+      disabled,
+      color,
+      handleClear,
+      showPassword,
+    ])
+
+    const renderBottomComponent = useCallback(() => {
+      if (!!props.error) {
+        return (
+          <Text color="red100" variant="xs" px={`${HORIZONTAL_PADDING}px`} mt={0.5}>
+            {props.error}
+          </Text>
+        )
+      }
 
       return (
-        <Flex flexGrow={1}>
-          {renderAndroidPlaceholderMeasuringHack()}
-
-          {renderHint()}
-
-          {renderAnimatedTitle()}
-
-          <AnimatedStyledInput
-            // Only use a controlled input if specified
-            {...((propValue !== undefined && propValue !== null) || mask ? { value } : {})}
-            onChangeText={handleChangeText}
-            style={[styles, textInputAnimatedStyles]}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            onLayout={(event) => {
-              setInputWidth(event.nativeEvent.layout.width)
-            }}
-            scrollEnabled={props.multiline}
-            editable={!disabled}
-            textAlignVertical={props.multiline ? "top" : "center"}
-            ref={inputRef as RefObject<TextInput>}
-            placeholderTextColor={color("black60")}
-            placeholder={getPlaceholder()}
-            defaultValue={defaultValue}
-            secureTextEntry={!showPassword}
-            {...props}
-          />
-
-          {renderRightComponent()}
-
-          {renderLeftComponent()}
-
-          {/* Contains error and other data we display below the textinput */}
-          {renderBottomComponent()}
+        <Flex flexDirection="row" justifyContent="space-between">
+          {!!props.required || !!props.optional ? (
+            <Text color="black60" variant="xs" pl={`${HORIZONTAL_PADDING}px`} mt={0.5}>
+              {!!props.required && "* Required"}
+              {!!props.optional && "* Optional"}
+            </Text>
+          ) : (
+            // Adding this empty flex to make sure that the maxLength text is always on the right
+            <Flex />
+          )}
+          {!!props.maxLength && !!props.showLimit && (
+            <Text color="black60" variant="xs" pr={`${HORIZONTAL_PADDING}px`} mt={0.5}>
+              {(value || "").length} / {props.maxLength}
+            </Text>
+          )}
         </Flex>
       )
-    }
-  )
+    }, [props.error, props.maxLength, props.optional, props.required, props.showLimit, value])
+
+    const renderHint = useCallback(() => {
+      if (!props.onHintPress) {
+        return null
+      }
+
+      return (
+        <Flex
+          style={{
+            alignItems: "flex-end",
+            top: space(2),
+          }}
+        >
+          <Touchable
+            onPress={props.onHintPress}
+            haptic="impactLight"
+            hitSlop={{
+              top: 5,
+              right: 10,
+              bottom: 5,
+              left: 10,
+            }}
+          >
+            <Text underline variant="xs" color="black60">
+              {hintText}
+            </Text>
+          </Touchable>
+        </Flex>
+      )
+    }, [hintText, props.onHintPress, space])
+
+    const getPlatformSpecificPlaceholder = useCallback(() => {
+      if (!placeholder) {
+        return ""
+      }
+
+      if (Platform.OS === "ios") {
+        return isArray(placeholder) ? placeholder[0] : placeholder
+      }
+
+      // if it's android and we only have one string, return that string
+      if (isString(placeholder)) {
+        return placeholder
+      }
+      // otherwise, find a placeholder that has longest width that fits in the inputtext
+      const longestFittingStringIndex = placeholderWidths.current.findIndex((placeholderWidth) => {
+        return placeholderWidth <= inputWidth
+      })
+      if (longestFittingStringIndex > -1) {
+        return placeholder[longestFittingStringIndex]
+      }
+
+      // otherwise just return the shortest placeholder
+      return placeholder[placeholder.length - 1]
+    }, [inputWidth, placeholder])
+
+    const getPlaceholder = useCallback(() => {
+      // Show placeholder always if there is no title
+      // This is because we won't have a title animation
+      if (!props.title) {
+        return getPlatformSpecificPlaceholder()
+      }
+
+      // On blur, we want to show the placeholder immediately
+      if (delayedFocused) {
+        return getPlatformSpecificPlaceholder()
+      }
+
+      // On focus, we want to show the placeholder after the title animation has finished
+      return ""
+    }, [delayedFocused, getPlatformSpecificPlaceholder, props.title])
+
+    const renderAnimatedTitle = useCallback(() => {
+      if (!props.title) {
+        return null
+      }
+
+      return (
+        <Flex flexDirection="row" zIndex={100} pointerEvents="none" height={LABEL_HEIGHT}>
+          <AnimatedText style={[labelStyles, labelAnimatedStyles]} numberOfLines={1}>
+            {" "}
+            {props.title}{" "}
+          </AnimatedText>
+        </Flex>
+      )
+    }, [labelStyles, labelAnimatedStyles, props.title])
+
+    const renderAndroidPlaceholderMeasuringHack = useCallback(() => {
+      if (Platform.OS === "ios" || !isArray(placeholder)) {
+        return null
+      }
+
+      // Do not render the hack if we have already measured the placeholder
+      if (placeholderWidths.current.length > 0) {
+        return null
+      }
+
+      return (
+        <Flex
+          style={{
+            position: "absolute",
+            top: -10000, // make sure its off the screen
+            width: 10000, // make sure Texts can take as much space as they need
+            alignItems: "baseline", // this is to make Texts get the smallest width they can get to fit the text
+          }}
+        >
+          {placeholder.map((placeholderString, index) => (
+            <Text
+              onLayout={(event) => {
+                placeholderWidths.current[index] = event.nativeEvent.layout.width
+              }}
+              numberOfLines={1}
+              style={{
+                ...styles,
+              }}
+            >
+              {placeholderString}
+            </Text>
+          ))}
+        </Flex>
+      )
+    }, [placeholder, styles])
+
+    return (
+      <Flex flexGrow={1}>
+        {renderAndroidPlaceholderMeasuringHack()}
+
+        {renderHint()}
+
+        {renderAnimatedTitle()}
+
+        <AnimatedStyledInput
+          // Only use a controlled input if specified
+          {...((propValue !== undefined && propValue !== null) || mask ? { value } : {})}
+          onChangeText={handleChangeText}
+          style={[styles, textInputAnimatedStyles]}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onLayout={(event) => {
+            setInputWidth(event.nativeEvent.layout.width)
+          }}
+          scrollEnabled={props.multiline}
+          editable={!disabled}
+          textAlignVertical={props.multiline ? "top" : "center"}
+          ref={inputRef as RefObject<TextInput>}
+          placeholderTextColor={color("black60")}
+          placeholder={getPlaceholder()}
+          defaultValue={defaultValue}
+          secureTextEntry={!showPassword}
+          {...props}
+        />
+
+        {renderRightComponent()}
+
+        {renderLeftComponent()}
+
+        {/* Contains error and other data we display below the textinput */}
+        {renderBottomComponent()}
+      </Flex>
+    )
+  }
 )
 
 const StyledInput = styled(TextInput)`

--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -7,6 +7,7 @@ import isString from "lodash/isString"
 import {
   RefObject,
   forwardRef,
+  memo,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -26,7 +27,13 @@ import {
 } from "react-native"
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated"
 import styled from "styled-components"
-import { INPUT_VARIANTS, InputState, InputVariant, getInputState, getInputVariant } from "./helpers"
+import {
+  getInputVariants,
+  InputState,
+  InputVariant,
+  getInputState,
+  getInputVariant,
+} from "./helpers"
 import { maskValue, unmaskText } from "./maskValue"
 import { EyeClosedIcon, EyeOpenedIcon, TriangleDown, XCircleIcon } from "../../svgs"
 import { useTheme } from "../../utils/hooks"
@@ -126,610 +133,621 @@ export interface InputRef {
   clear: () => void
 }
 
-export const Input = forwardRef<InputRef, InputProps>(
-  (
-    {
-      addClearListener = false,
-      defaultValue,
-      disabled = false,
-      enableClearButton = false,
-      fixedRightPlaceholder,
-      hintText = "What's this?",
-      icon,
-      leftComponentWidth = LEFT_COMPONENT_WIDTH,
-      mask,
-      selectComponentWidth = SELECT_COMPONENT_WIDTH,
-      loading = false,
-      onBlur,
-      onChangeText,
-      onClear,
-      onFocus,
-      onSelectTap,
-      placeholder,
-      secureTextEntry = false,
-      style: styleProp = {},
-      unit,
-      value: propValue,
-      selectDisplayLabel,
-      ...props
-    },
-    ref
-  ) => {
-    const { color, theme, space } = useTheme()
-
-    const [focused, setIsFocused] = useState(false)
-    const [delayedFocused, setDelayedFocused] = useState(false)
-
-    const [value, setValue] = useState(
-      maskValue({
-        currentValue: propValue ?? defaultValue,
-        mask: mask,
-      })
-    )
-
-    const [showPassword, setShowPassword] = useState(!secureTextEntry)
-
-    const [inputWidth, setInputWidth] = useState(0)
-    const placeholderWidths = useRef<number[]>([])
-
-    const rightComponentRef = useRef(null)
-    const inputRef = useRef<TextInput>()
-
-    const variant: InputVariant = getInputVariant({
-      hasError: !!props.error,
-      disabled: disabled,
-    })
-
-    const hasLeftComponent = useMemo(
-      () => !!unit || !!icon || !!onSelectTap,
-      [unit, icon, onSelectTap]
-    )
-
-    const animatedState = useSharedValue<InputState>(
-      getInputState({
-        isFocused: !!focused,
-        value: value,
-      })
-    )
-
-    useImperativeHandle(ref, () => inputRef.current as InputRef)
-
-    useEffect(() => {
-      // If the prop value changes, update the local state
-      // This optimisation is not needed if no propValue has been specified
-      if (propValue !== undefined && propValue !== value) {
-        setValue(maskValue({ currentValue: propValue || "", mask }))
-      }
-    }, [propValue, value, mask])
-
-    useEffect(() => {
-      // If the mask value changes, update the value state to be formatted again
-      setValue(maskValue({ currentValue: value, mask }))
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [mask])
-
-    const fontFamily = theme.fonts.sans.regular
-
-    useEffect(() => {
-      /* to make the font work for secure text inputs,
-      see https://github.com/facebook/react-native/issues/30123#issuecomment-711076098 */
-      inputRef.current?.setNativeProps({
-        style: { fontFamily },
-      })
-    }, [fontFamily])
-
-    useEffect(() => {
-      // We don't need to delay hiding the placeholder
-      if (!focused && delayedFocused) {
-        setDelayedFocused(false)
-      }
-
-      let delayFocusedTimeout: NodeJS.Timeout
-
-      // We only want to show the placeholder after we're sure the title animation has finished
-      if (!delayedFocused && focused) {
-        delayFocusedTimeout = setTimeout(() => {
-          setDelayedFocused(focused)
-        }, 200)
-      }
-
-      return () => {
-        if (delayFocusedTimeout) {
-          clearTimeout(delayFocusedTimeout)
-        }
-      }
-    }, [focused, delayedFocused])
-
-    const handleChangeText = useCallback(
-      (text: string) => {
-        if (mask) {
-          const newText = maskValue({ currentValue: text, mask: mask, previousValue: value }) || ""
-          setValue(newText)
-          onChangeText?.(newText, unmaskText(text))
-        } else {
-          setValue(text)
-          onChangeText?.(text)
-        }
+export const Input = memo(
+  forwardRef<InputRef, InputProps>(
+    (
+      {
+        addClearListener = false,
+        defaultValue,
+        disabled = false,
+        enableClearButton = false,
+        fixedRightPlaceholder,
+        hintText = "What's this?",
+        icon,
+        leftComponentWidth = LEFT_COMPONENT_WIDTH,
+        mask,
+        selectComponentWidth = SELECT_COMPONENT_WIDTH,
+        loading = false,
+        onBlur,
+        onChangeText,
+        onClear,
+        onFocus,
+        onSelectTap,
+        placeholder,
+        secureTextEntry = false,
+        style: styleProp = {},
+        unit,
+        value: propValue,
+        selectDisplayLabel,
+        ...props
       },
-      [onChangeText, value, mask]
-    )
+      ref
+    ) => {
+      const { color, theme, space } = useTheme()
 
-    const handleClear = useCallback(() => {
-      LayoutAnimation.configureNext({ ...LayoutAnimation.Presets.easeInEaseOut, duration: 200 })
-      inputRef.current?.clear()
-      handleChangeText("")
-      onClear?.()
-    }, [onClear, handleChangeText])
+      const [focused, setIsFocused] = useState(false)
+      const [delayedFocused, setDelayedFocused] = useState(false)
 
-    useEffect(() => {
-      if (!addClearListener) {
-        return
-      }
+      const [value, setValue] = useState(
+        maskValue({
+          currentValue: propValue ?? defaultValue,
+          mask: mask,
+        })
+      )
 
-      inputEvents.addListener("clear", handleClear)
+      const [showPassword, setShowPassword] = useState(!secureTextEntry)
 
-      return () => {
-        inputEvents.removeListener("clear", handleClear)
-      }
-    }, [addClearListener, handleClear])
+      const [inputWidth, setInputWidth] = useState(0)
+      const placeholderWidths = useRef<number[]>([])
 
-    const { width: rightComponentWidth = 0 } = useMeasure({ ref: rightComponentRef })
+      const rightComponentRef = useRef(null)
+      const inputRef = useRef<TextInput>()
 
-    const textInputPaddingLeft = useMemo(() => {
-      if (!hasLeftComponent) {
-        return HORIZONTAL_PADDING
-      }
-
-      if (onSelectTap) {
-        return selectComponentWidth + HORIZONTAL_PADDING
-      }
-
-      return leftComponentWidth
-    }, [hasLeftComponent, leftComponentWidth, onSelectTap, selectComponentWidth])
-
-    const styles = useMemo(() => {
-      return {
-        fontFamily: fontFamily,
-        fontSize: parseInt(THEME.textVariants["sm-display"].fontSize, 10),
-        minHeight: props.multiline ? MULTILINE_INPUT_MIN_HEIGHT : INPUT_MIN_HEIGHT,
-        maxHeight: props.multiline ? MULTILINE_INPUT_MAX_HEIGHT : undefined,
-        height: props.multiline ? MULTILINE_INPUT_MIN_HEIGHT : undefined,
-        borderWidth: 1,
-        paddingRight: rightComponentWidth + HORIZONTAL_PADDING,
-        paddingLeft: textInputPaddingLeft,
-        ...(styleProp as {}),
-      }
-    }, [fontFamily, styleProp, props.multiline, rightComponentWidth, textInputPaddingLeft])
-
-    const labelStyles = useMemo(() => {
-      return {
-        // this is neeeded too make sure the label is on top of the input
-        backgroundColor: "white",
-        marginRight: space(0.5),
-        zIndex: 100,
-        fontFamily: fontFamily,
-      }
-    }, [fontFamily, space])
-
-    useEffect(() => {
-      const inputState = getInputState({
-        isFocused: !!focused,
-        value: value,
+      const variant: InputVariant = getInputVariant({
+        hasError: !!props.error,
+        disabled: disabled,
       })
-      animatedState.set(() => inputState)
-    }, [value, focused, animatedState])
 
-    const textInputAnimatedStyles = useAnimatedStyle(() => {
-      return {
-        borderColor: withTiming(INPUT_VARIANTS[variant][animatedState.get()].inputBorderColor),
-        color: withTiming(INPUT_VARIANTS[variant][animatedState.get()].inputTextColor),
+      const hasLeftComponent = useMemo(
+        () => !!unit || !!icon || !!onSelectTap,
+        [unit, icon, onSelectTap]
+      )
+
+      const animatedState = useSharedValue<InputState>(
+        getInputState({
+          isFocused: !!focused,
+          value: value,
+        })
+      )
+
+      useImperativeHandle(ref, () => inputRef.current as InputRef)
+
+      useEffect(() => {
+        // If the prop value changes, update the local state
+        // This optimisation is not needed if no propValue has been specified
+        if (propValue !== undefined && propValue !== value) {
+          setValue(maskValue({ currentValue: propValue || "", mask }))
+        }
+      }, [propValue, value, mask])
+
+      useEffect(() => {
+        // If the mask value changes, update the value state to be formatted again
+        setValue(maskValue({ currentValue: value, mask }))
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, [mask])
+
+      const fontFamily = theme.fonts.sans.regular
+
+      useEffect(() => {
+        /* to make the font work for secure text inputs,
+      see https://github.com/facebook/react-native/issues/30123#issuecomment-711076098 */
+        inputRef.current?.setNativeProps({
+          style: { fontFamily },
+        })
+      }, [fontFamily])
+
+      useEffect(() => {
+        // We don't need to delay hiding the placeholder
+        if (!focused && delayedFocused) {
+          setDelayedFocused(false)
+        }
+
+        let delayFocusedTimeout: NodeJS.Timeout
+
+        // We only want to show the placeholder after we're sure the title animation has finished
+        if (!delayedFocused && focused) {
+          delayFocusedTimeout = setTimeout(() => {
+            setDelayedFocused(focused)
+          }, 200)
+        }
+
+        return () => {
+          if (delayFocusedTimeout) {
+            clearTimeout(delayFocusedTimeout)
+          }
+        }
+      }, [focused, delayedFocused])
+
+      const handleChangeText = useCallback(
+        (text: string) => {
+          if (mask) {
+            const newText =
+              maskValue({ currentValue: text, mask: mask, previousValue: value }) || ""
+            setValue(newText)
+            onChangeText?.(newText, unmaskText(text))
+          } else {
+            setValue(text)
+            onChangeText?.(text)
+          }
+        },
+        [onChangeText, value, mask]
+      )
+
+      const handleClear = useCallback(() => {
+        LayoutAnimation.configureNext({ ...LayoutAnimation.Presets.easeInEaseOut, duration: 200 })
+        inputRef.current?.clear()
+        handleChangeText("")
+        onClear?.()
+      }, [onClear, handleChangeText])
+
+      useEffect(() => {
+        if (!addClearListener) {
+          return
+        }
+
+        inputEvents.addListener("clear", handleClear)
+
+        return () => {
+          inputEvents.removeListener("clear", handleClear)
+        }
+      }, [addClearListener, handleClear])
+
+      const { width: rightComponentWidth = 0 } = useMeasure({ ref: rightComponentRef })
+
+      const textInputPaddingLeft = useMemo(() => {
+        if (!hasLeftComponent) {
+          return HORIZONTAL_PADDING
+        }
+
+        if (onSelectTap) {
+          return selectComponentWidth + HORIZONTAL_PADDING
+        }
+
+        return leftComponentWidth
+      }, [hasLeftComponent, leftComponentWidth, onSelectTap, selectComponentWidth])
+
+      const styles = useMemo(() => {
+        return {
+          fontFamily: fontFamily,
+          fontSize: parseInt(THEME.textVariants["sm-display"].fontSize, 10),
+          minHeight: props.multiline ? MULTILINE_INPUT_MIN_HEIGHT : INPUT_MIN_HEIGHT,
+          maxHeight: props.multiline ? MULTILINE_INPUT_MAX_HEIGHT : undefined,
+          height: props.multiline ? MULTILINE_INPUT_MIN_HEIGHT : undefined,
+          borderWidth: 1,
+          paddingRight: rightComponentWidth + HORIZONTAL_PADDING,
+          paddingLeft: textInputPaddingLeft,
+          ...(styleProp as {}),
+        }
+      }, [fontFamily, styleProp, props.multiline, rightComponentWidth, textInputPaddingLeft])
+
+      const labelStyles = useMemo(() => {
+        return {
+          // this is neeeded too make sure the label is on top of the input
+          backgroundColor: color("background"),
+          marginRight: space(0.5),
+          zIndex: 100,
+          fontFamily: fontFamily,
+        }
+      }, [fontFamily, space, color])
+
+      const inputVariants = getInputVariants(theme)
+
+      useEffect(() => {
+        const inputState = getInputState({
+          isFocused: !!focused,
+          value: value,
+        })
+        animatedState.set(() => inputState)
+      }, [value, focused, animatedState])
+
+      const textInputAnimatedStyles = useAnimatedStyle(() => {
+        return {
+          borderColor: withTiming(inputVariants[variant][animatedState.get()].inputBorderColor),
+          color: withTiming(inputVariants[variant][animatedState.get()].inputTextColor),
+        }
+      })
+
+      const labelAnimatedStyles = useAnimatedStyle(() => {
+        const hasValue = !!value
+
+        // Only add a margin if the input has a left component and it is not focused and has no value
+        const marginLeft =
+          textInputPaddingLeft && !focused && !hasValue
+            ? textInputPaddingLeft - 3
+            : HORIZONTAL_PADDING
+
+        return {
+          color: withTiming(inputVariants[variant][animatedState.get()].labelColor),
+          top: withTiming(inputVariants[variant][animatedState.get()].labelTop),
+          fontSize: withTiming(inputVariants[variant][animatedState.get()].labelFontSize),
+          marginLeft: withTiming(marginLeft),
+        }
+      })
+
+      const selectComponentStyles = useAnimatedStyle(() => {
+        return {
+          borderColor: withTiming(inputVariants[variant][animatedState.get()].inputBorderColor),
+        }
+      })
+
+      const handleFocus = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
+        setIsFocused(true)
+        onFocus?.(e)
       }
-    })
 
-    const labelAnimatedStyles = useAnimatedStyle(() => {
-      const hasValue = !!value
-
-      // Only add a margin if the input has a left component and it is not focused and has no value
-      const marginLeft =
-        textInputPaddingLeft && !focused && !hasValue
-          ? textInputPaddingLeft - 3
-          : HORIZONTAL_PADDING
-
-      return {
-        color: withTiming(INPUT_VARIANTS[variant][animatedState.get()].labelColor),
-        top: withTiming(INPUT_VARIANTS[variant][animatedState.get()].labelTop),
-        fontSize: withTiming(INPUT_VARIANTS[variant][animatedState.get()].labelFontSize),
-        marginLeft: withTiming(marginLeft),
-      }
-    })
-
-    const selectComponentStyles = useAnimatedStyle(() => {
-      return {
-        borderColor: withTiming(INPUT_VARIANTS[variant][animatedState.get()].inputBorderColor),
-      }
-    })
-
-    const handleFocus = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
-      setIsFocused(true)
-      onFocus?.(e)
-    }
-
-    const handleBlur = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
-      setIsFocused(false)
-      onBlur?.(e)
-    }
-
-    const hasTitle = !!props.title
-
-    const renderLeftComponent = useCallback(() => {
-      const leftComponentSharedStyles: ViewProps["style"] = {
-        position: "absolute",
-        paddingHorizontal: HORIZONTAL_PADDING,
-        height: INPUT_MIN_HEIGHT,
-        top: hasTitle ? LABEL_HEIGHT : 0,
-        alignItems: "center",
-        zIndex: 100,
+      const handleBlur = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
+        setIsFocused(false)
+        onBlur?.(e)
       }
 
-      if (unit || icon) {
+      const hasTitle = !!props.title
+
+      const renderLeftComponent = useCallback(() => {
+        const leftComponentSharedStyles: ViewProps["style"] = {
+          position: "absolute",
+          paddingHorizontal: HORIZONTAL_PADDING,
+          height: INPUT_MIN_HEIGHT,
+          top: hasTitle ? LABEL_HEIGHT : 0,
+          alignItems: "center",
+          zIndex: 100,
+        }
+
+        if (unit || icon) {
+          return (
+            <Flex
+              style={{
+                ...leftComponentSharedStyles,
+                justifyContent: "center",
+                width: leftComponentWidth,
+              }}
+            >
+              {unit && (
+                <Text color={disabled ? "black30" : "black60"} variant="sm-display">
+                  {unit}
+                </Text>
+              )}
+              {icon}
+            </Flex>
+          )
+        }
+
+        if (onSelectTap) {
+          return (
+            <TouchableOpacity
+              onPress={onSelectTap}
+              style={[
+                leftComponentSharedStyles,
+                {
+                  width: selectComponentWidth,
+                },
+              ]}
+              hitSlop={{ top: 10, right: 10, bottom: 10, left: 10 }}
+            >
+              <AnimatedFlex
+                style={[
+                  {
+                    paddingHorizontal: HORIZONTAL_PADDING,
+                    height: INPUT_MIN_HEIGHT,
+                    alignItems: "center",
+                    width: selectComponentWidth,
+                    flexDirection: "row",
+                    borderRightWidth: 1,
+                    justifyContent: "space-between",
+                  },
+                  selectComponentStyles,
+                ]}
+              >
+                <Text color={disabled ? "black30" : "black100"}>{selectDisplayLabel}</Text>
+                <TriangleDown fill="black60" width={10} />
+              </AnimatedFlex>
+            </TouchableOpacity>
+          )
+        }
+
+        return null
+      }, [
+        hasTitle,
+        unit,
+        icon,
+        onSelectTap,
+        leftComponentWidth,
+        disabled,
+        selectComponentWidth,
+        selectComponentStyles,
+        selectDisplayLabel,
+      ])
+
+      const renderRightComponent = useCallback(() => {
+        if (fixedRightPlaceholder) {
+          return (
+            <Flex
+              justifyContent="center"
+              position="absolute"
+              right={`${HORIZONTAL_PADDING}px`}
+              top={hasTitle ? LABEL_HEIGHT : 0}
+              height={INPUT_MIN_HEIGHT}
+              ref={rightComponentRef}
+            >
+              <Text color={disabled ? "black30" : "black60"}>{fixedRightPlaceholder}</Text>
+            </Flex>
+          )
+        }
+
+        if (loading) {
+          return (
+            <Flex
+              justifyContent="center"
+              position="absolute"
+              right={`${HORIZONTAL_PADDING}px`}
+              top={hasTitle ? LABEL_HEIGHT : 0}
+              height={INPUT_MIN_HEIGHT}
+              ref={rightComponentRef}
+            >
+              <Spinner
+                size="medium"
+                style={{
+                  right: 0,
+                  width: 15,
+                  backgroundColor: color("black60"),
+                }}
+              />
+            </Flex>
+          )
+        }
+
+        if (enableClearButton && value) {
+          return (
+            <Flex
+              justifyContent="center"
+              position="absolute"
+              right={`${HORIZONTAL_PADDING}px`}
+              top={hasTitle ? LABEL_HEIGHT : 0}
+              height={INPUT_MIN_HEIGHT}
+              zIndex={100}
+              ref={rightComponentRef}
+            >
+              <Touchable
+                haptic="impactMedium"
+                onPress={handleClear}
+                hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
+                accessibilityLabel="Clear input button"
+                testID="clear-input-button"
+              >
+                <XCircleIcon fill="black30" />
+              </Touchable>
+            </Flex>
+          )
+        }
+
+        if (secureTextEntry) {
+          return (
+            <Flex
+              justifyContent="center"
+              position="absolute"
+              right={`${HORIZONTAL_PADDING}px`}
+              top={hasTitle ? LABEL_HEIGHT : 0}
+              height={INPUT_MIN_HEIGHT}
+              zIndex={100}
+              ref={rightComponentRef}
+            >
+              <Touchable
+                haptic
+                onPress={() => {
+                  LayoutAnimation.configureNext({
+                    ...LayoutAnimation.Presets.easeInEaseOut,
+                    duration: 200,
+                  })
+                  setShowPassword(!showPassword)
+                }}
+                accessibilityLabel={showPassword ? "hide password button" : "show password button"}
+                hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
+              >
+                {!showPassword ? (
+                  <EyeClosedIcon fill="black30" />
+                ) : (
+                  <EyeOpenedIcon fill="black60" />
+                )}
+              </Touchable>
+            </Flex>
+          )
+        }
+
+        return null
+      }, [
+        fixedRightPlaceholder,
+        loading,
+        enableClearButton,
+        value,
+        secureTextEntry,
+        hasTitle,
+        disabled,
+        color,
+        handleClear,
+        showPassword,
+      ])
+
+      const renderBottomComponent = useCallback(() => {
+        if (!!props.error) {
+          return (
+            <Text color="red100" variant="xs" px={`${HORIZONTAL_PADDING}px`} mt={0.5}>
+              {props.error}
+            </Text>
+          )
+        }
+
+        return (
+          <Flex flexDirection="row" justifyContent="space-between">
+            {!!props.required || !!props.optional ? (
+              <Text color="black60" variant="xs" pl={`${HORIZONTAL_PADDING}px`} mt={0.5}>
+                {!!props.required && "* Required"}
+                {!!props.optional && "* Optional"}
+              </Text>
+            ) : (
+              // Adding this empty flex to make sure that the maxLength text is always on the right
+              <Flex />
+            )}
+            {!!props.maxLength && !!props.showLimit && (
+              <Text color="black60" variant="xs" pr={`${HORIZONTAL_PADDING}px`} mt={0.5}>
+                {(value || "").length} / {props.maxLength}
+              </Text>
+            )}
+          </Flex>
+        )
+      }, [props.error, props.maxLength, props.optional, props.required, props.showLimit, value])
+
+      const renderHint = useCallback(() => {
+        if (!props.onHintPress) {
+          return null
+        }
+
         return (
           <Flex
             style={{
-              ...leftComponentSharedStyles,
-              justifyContent: "center",
-              width: leftComponentWidth,
+              alignItems: "flex-end",
+              top: space(2),
             }}
           >
-            {unit && (
-              <Text color={disabled ? "black30" : "black60"} variant="sm-display">
-                {unit}
+            <Touchable
+              onPress={props.onHintPress}
+              haptic="impactLight"
+              hitSlop={{
+                top: 5,
+                right: 10,
+                bottom: 5,
+                left: 10,
+              }}
+            >
+              <Text underline variant="xs" color="black60">
+                {hintText}
               </Text>
-            )}
-            {icon}
-          </Flex>
-        )
-      }
-
-      if (onSelectTap) {
-        return (
-          <TouchableOpacity
-            onPress={onSelectTap}
-            style={[
-              leftComponentSharedStyles,
-              {
-                width: selectComponentWidth,
-              },
-            ]}
-            hitSlop={{ top: 10, right: 10, bottom: 10, left: 10 }}
-          >
-            <AnimatedFlex
-              style={[
-                {
-                  paddingHorizontal: HORIZONTAL_PADDING,
-                  height: INPUT_MIN_HEIGHT,
-                  alignItems: "center",
-                  width: selectComponentWidth,
-                  flexDirection: "row",
-                  borderRightWidth: 1,
-                  justifyContent: "space-between",
-                },
-                selectComponentStyles,
-              ]}
-            >
-              <Text color={disabled ? "black30" : "black100"}>{selectDisplayLabel}</Text>
-              <TriangleDown fill="black60" width={10} />
-            </AnimatedFlex>
-          </TouchableOpacity>
-        )
-      }
-
-      return null
-    }, [
-      hasTitle,
-      unit,
-      icon,
-      onSelectTap,
-      leftComponentWidth,
-      disabled,
-      selectComponentWidth,
-      selectComponentStyles,
-      selectDisplayLabel,
-    ])
-
-    const renderRightComponent = useCallback(() => {
-      if (fixedRightPlaceholder) {
-        return (
-          <Flex
-            justifyContent="center"
-            position="absolute"
-            right={`${HORIZONTAL_PADDING}px`}
-            top={hasTitle ? LABEL_HEIGHT : 0}
-            height={INPUT_MIN_HEIGHT}
-            ref={rightComponentRef}
-          >
-            <Text color={disabled ? "black30" : "black60"}>{fixedRightPlaceholder}</Text>
-          </Flex>
-        )
-      }
-
-      if (loading) {
-        return (
-          <Flex
-            justifyContent="center"
-            position="absolute"
-            right={`${HORIZONTAL_PADDING}px`}
-            top={hasTitle ? LABEL_HEIGHT : 0}
-            height={INPUT_MIN_HEIGHT}
-            ref={rightComponentRef}
-          >
-            <Spinner
-              size="medium"
-              style={{
-                right: 0,
-                width: 15,
-                backgroundColor: color("black60"),
-              }}
-            />
-          </Flex>
-        )
-      }
-
-      if (enableClearButton && value) {
-        return (
-          <Flex
-            justifyContent="center"
-            position="absolute"
-            right={`${HORIZONTAL_PADDING}px`}
-            top={hasTitle ? LABEL_HEIGHT : 0}
-            height={INPUT_MIN_HEIGHT}
-            zIndex={100}
-            ref={rightComponentRef}
-          >
-            <Touchable
-              haptic="impactMedium"
-              onPress={handleClear}
-              hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
-              accessibilityLabel="Clear input button"
-              testID="clear-input-button"
-            >
-              <XCircleIcon fill="black30" />
             </Touchable>
           </Flex>
         )
-      }
+      }, [hintText, props.onHintPress, space])
 
-      if (secureTextEntry) {
+      const getPlatformSpecificPlaceholder = useCallback(() => {
+        if (!placeholder) {
+          return ""
+        }
+
+        if (Platform.OS === "ios") {
+          return isArray(placeholder) ? placeholder[0] : placeholder
+        }
+
+        // if it's android and we only have one string, return that string
+        if (isString(placeholder)) {
+          return placeholder
+        }
+        // otherwise, find a placeholder that has longest width that fits in the inputtext
+        const longestFittingStringIndex = placeholderWidths.current.findIndex(
+          (placeholderWidth) => {
+            return placeholderWidth <= inputWidth
+          }
+        )
+        if (longestFittingStringIndex > -1) {
+          return placeholder[longestFittingStringIndex]
+        }
+
+        // otherwise just return the shortest placeholder
+        return placeholder[placeholder.length - 1]
+      }, [inputWidth, placeholder])
+
+      const getPlaceholder = useCallback(() => {
+        // Show placeholder always if there is no title
+        // This is because we won't have a title animation
+        if (!props.title) {
+          return getPlatformSpecificPlaceholder()
+        }
+
+        // On blur, we want to show the placeholder immediately
+        if (delayedFocused) {
+          return getPlatformSpecificPlaceholder()
+        }
+
+        // On focus, we want to show the placeholder after the title animation has finished
+        return ""
+      }, [delayedFocused, getPlatformSpecificPlaceholder, props.title])
+
+      const renderAnimatedTitle = useCallback(() => {
+        if (!props.title) {
+          return null
+        }
+
         return (
-          <Flex
-            justifyContent="center"
-            position="absolute"
-            right={`${HORIZONTAL_PADDING}px`}
-            top={hasTitle ? LABEL_HEIGHT : 0}
-            height={INPUT_MIN_HEIGHT}
-            zIndex={100}
-            ref={rightComponentRef}
-          >
-            <Touchable
-              haptic
-              onPress={() => {
-                LayoutAnimation.configureNext({
-                  ...LayoutAnimation.Presets.easeInEaseOut,
-                  duration: 200,
-                })
-                setShowPassword(!showPassword)
-              }}
-              accessibilityLabel={showPassword ? "hide password button" : "show password button"}
-              hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
-            >
-              {!showPassword ? <EyeClosedIcon fill="black30" /> : <EyeOpenedIcon fill="black60" />}
-            </Touchable>
+          <Flex flexDirection="row" zIndex={100} pointerEvents="none" height={LABEL_HEIGHT}>
+            <AnimatedText style={[labelStyles, labelAnimatedStyles]} numberOfLines={1}>
+              {" "}
+              {props.title}{" "}
+            </AnimatedText>
           </Flex>
         )
-      }
+      }, [labelStyles, labelAnimatedStyles, props.title])
 
-      return null
-    }, [
-      fixedRightPlaceholder,
-      loading,
-      enableClearButton,
-      value,
-      secureTextEntry,
-      hasTitle,
-      disabled,
-      color,
-      handleClear,
-      showPassword,
-    ])
+      const renderAndroidPlaceholderMeasuringHack = useCallback(() => {
+        if (Platform.OS === "ios" || !isArray(placeholder)) {
+          return null
+        }
 
-    const renderBottomComponent = useCallback(() => {
-      if (!!props.error) {
+        // Do not render the hack if we have already measured the placeholder
+        if (placeholderWidths.current.length > 0) {
+          return null
+        }
+
         return (
-          <Text color="red100" variant="xs" px={`${HORIZONTAL_PADDING}px`} mt={0.5}>
-            {props.error}
-          </Text>
-        )
-      }
-
-      return (
-        <Flex flexDirection="row" justifyContent="space-between">
-          {!!props.required || !!props.optional ? (
-            <Text color="black60" variant="xs" pl={`${HORIZONTAL_PADDING}px`} mt={0.5}>
-              {!!props.required && "* Required"}
-              {!!props.optional && "* Optional"}
-            </Text>
-          ) : (
-            // Adding this empty flex to make sure that the maxLength text is always on the right
-            <Flex />
-          )}
-          {!!props.maxLength && !!props.showLimit && (
-            <Text color="black60" variant="xs" pr={`${HORIZONTAL_PADDING}px`} mt={0.5}>
-              {(value || "").length} / {props.maxLength}
-            </Text>
-          )}
-        </Flex>
-      )
-    }, [props.error, props.maxLength, props.optional, props.required, props.showLimit, value])
-
-    const renderHint = useCallback(() => {
-      if (!props.onHintPress) {
-        return null
-      }
-
-      return (
-        <Flex
-          style={{
-            alignItems: "flex-end",
-            top: space(2),
-          }}
-        >
-          <Touchable
-            onPress={props.onHintPress}
-            haptic="impactLight"
-            hitSlop={{
-              top: 5,
-              right: 10,
-              bottom: 5,
-              left: 10,
+          <Flex
+            style={{
+              position: "absolute",
+              top: -10000, // make sure its off the screen
+              width: 10000, // make sure Texts can take as much space as they need
+              alignItems: "baseline", // this is to make Texts get the smallest width they can get to fit the text
             }}
           >
-            <Text underline variant="xs" color="black60">
-              {hintText}
-            </Text>
-          </Touchable>
-        </Flex>
-      )
-    }, [hintText, props.onHintPress, space])
-
-    const getPlatformSpecificPlaceholder = useCallback(() => {
-      if (!placeholder) {
-        return ""
-      }
-
-      if (Platform.OS === "ios") {
-        return isArray(placeholder) ? placeholder[0] : placeholder
-      }
-
-      // if it's android and we only have one string, return that string
-      if (isString(placeholder)) {
-        return placeholder
-      }
-      // otherwise, find a placeholder that has longest width that fits in the inputtext
-      const longestFittingStringIndex = placeholderWidths.current.findIndex((placeholderWidth) => {
-        return placeholderWidth <= inputWidth
-      })
-      if (longestFittingStringIndex > -1) {
-        return placeholder[longestFittingStringIndex]
-      }
-
-      // otherwise just return the shortest placeholder
-      return placeholder[placeholder.length - 1]
-    }, [inputWidth, placeholder])
-
-    const getPlaceholder = useCallback(() => {
-      // Show placeholder always if there is no title
-      // This is because we won't have a title animation
-      if (!props.title) {
-        return getPlatformSpecificPlaceholder()
-      }
-
-      // On blur, we want to show the placeholder immediately
-      if (delayedFocused) {
-        return getPlatformSpecificPlaceholder()
-      }
-
-      // On focus, we want to show the placeholder after the title animation has finished
-      return ""
-    }, [delayedFocused, getPlatformSpecificPlaceholder, props.title])
-
-    const renderAnimatedTitle = useCallback(() => {
-      if (!props.title) {
-        return null
-      }
+            {placeholder.map((placeholderString, index) => (
+              <Text
+                onLayout={(event) => {
+                  placeholderWidths.current[index] = event.nativeEvent.layout.width
+                }}
+                numberOfLines={1}
+                style={{
+                  ...styles,
+                }}
+              >
+                {placeholderString}
+              </Text>
+            ))}
+          </Flex>
+        )
+      }, [placeholder, styles])
 
       return (
-        <Flex flexDirection="row" zIndex={100} pointerEvents="none" height={LABEL_HEIGHT}>
-          <AnimatedText style={[labelStyles, labelAnimatedStyles]} numberOfLines={1}>
-            {" "}
-            {props.title}{" "}
-          </AnimatedText>
+        <Flex flexGrow={1}>
+          {renderAndroidPlaceholderMeasuringHack()}
+
+          {renderHint()}
+
+          {renderAnimatedTitle()}
+
+          <AnimatedStyledInput
+            // Only use a controlled input if specified
+            {...((propValue !== undefined && propValue !== null) || mask ? { value } : {})}
+            onChangeText={handleChangeText}
+            style={[styles, textInputAnimatedStyles]}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onLayout={(event) => {
+              setInputWidth(event.nativeEvent.layout.width)
+            }}
+            scrollEnabled={props.multiline}
+            editable={!disabled}
+            textAlignVertical={props.multiline ? "top" : "center"}
+            ref={inputRef as RefObject<TextInput>}
+            placeholderTextColor={color("black60")}
+            placeholder={getPlaceholder()}
+            defaultValue={defaultValue}
+            secureTextEntry={!showPassword}
+            {...props}
+          />
+
+          {renderRightComponent()}
+
+          {renderLeftComponent()}
+
+          {/* Contains error and other data we display below the textinput */}
+          {renderBottomComponent()}
         </Flex>
       )
-    }, [labelStyles, labelAnimatedStyles, props.title])
-
-    const renderAndroidPlaceholderMeasuringHack = useCallback(() => {
-      if (Platform.OS === "ios" || !isArray(placeholder)) {
-        return null
-      }
-
-      // Do not render the hack if we have already measured the placeholder
-      if (placeholderWidths.current.length > 0) {
-        return null
-      }
-
-      return (
-        <Flex
-          style={{
-            position: "absolute",
-            top: -10000, // make sure its off the screen
-            width: 10000, // make sure Texts can take as much space as they need
-            alignItems: "baseline", // this is to make Texts get the smallest width they can get to fit the text
-          }}
-        >
-          {placeholder.map((placeholderString, index) => (
-            <Text
-              onLayout={(event) => {
-                placeholderWidths.current[index] = event.nativeEvent.layout.width
-              }}
-              numberOfLines={1}
-              style={{
-                ...styles,
-              }}
-            >
-              {placeholderString}
-            </Text>
-          ))}
-        </Flex>
-      )
-    }, [placeholder, styles])
-
-    return (
-      <Flex flexGrow={1}>
-        {renderAndroidPlaceholderMeasuringHack()}
-
-        {renderHint()}
-
-        {renderAnimatedTitle()}
-
-        <AnimatedStyledInput
-          // Only use a controlled input if specified
-          {...((propValue !== undefined && propValue !== null) || mask ? { value } : {})}
-          onChangeText={handleChangeText}
-          style={[styles, textInputAnimatedStyles]}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          onLayout={(event) => {
-            setInputWidth(event.nativeEvent.layout.width)
-          }}
-          scrollEnabled={props.multiline}
-          editable={!disabled}
-          textAlignVertical={props.multiline ? "top" : "center"}
-          ref={inputRef as RefObject<TextInput>}
-          placeholderTextColor={color("black60")}
-          placeholder={getPlaceholder()}
-          defaultValue={defaultValue}
-          secureTextEntry={!showPassword}
-          {...props}
-        />
-
-        {renderRightComponent()}
-
-        {renderLeftComponent()}
-
-        {/* Contains error and other data we display below the textinput */}
-        {renderBottomComponent()}
-      </Flex>
-    )
-  }
+    }
+  )
 )
 
 const StyledInput = styled(TextInput)`

--- a/src/elements/Input/helpers.ts
+++ b/src/elements/Input/helpers.ts
@@ -1,4 +1,5 @@
 import { THEME } from "@artsy/palette-tokens"
+import { ThemeType, ThemeWithDarkModeType } from "../../tokens"
 
 export const SHRINKED_LABEL_TOP = 13
 export const EXPANDED_LABEL_TOP = 40
@@ -27,96 +28,104 @@ export type VariantState = {
   }
 }
 
-const DEFAULT_VARIANT_STATES: VariantState = {
-  // Unfocused input with no value
-  untouched: {
-    inputBorderColor: THEME.colors.black30,
-    labelFontSize: parseInt(THEME.textVariants["sm-display"].fontSize, 10),
-    labelColor: THEME.colors.black60,
-    labelTop: EXPANDED_LABEL_TOP,
-    inputTextColor: THEME.colors.black100,
-  },
-  // Unfocused input with value
-  touched: {
-    inputBorderColor: THEME.colors.black60,
-    labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
-    labelColor: THEME.colors.black60,
-    labelTop: SHRINKED_LABEL_TOP,
-    inputTextColor: THEME.colors.black100,
-  },
-  // Focused input with or without value
-  focused: {
-    inputBorderColor: THEME.colors.blue100,
-    labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
-    labelColor: THEME.colors.blue100,
-    labelTop: SHRINKED_LABEL_TOP,
-    inputTextColor: THEME.colors.black100,
-  },
+const getDefaultVariantStates = (theme: ThemeType | ThemeWithDarkModeType): VariantState => {
+  return {
+    // Unfocused input with no value
+    untouched: {
+      inputBorderColor: theme.colors.black30,
+      labelFontSize: parseInt(THEME.textVariants["sm-display"].fontSize, 10),
+      labelColor: theme.colors.black60,
+      labelTop: EXPANDED_LABEL_TOP,
+      inputTextColor: theme.colors.white100,
+    },
+    // Unfocused input with value
+    touched: {
+      inputBorderColor: theme.colors.black60,
+      labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
+      labelColor: theme.colors.black60,
+      labelTop: SHRINKED_LABEL_TOP,
+      inputTextColor: theme.colors.white100,
+    },
+    // Focused input with or without value
+    focused: {
+      inputBorderColor: theme.colors.blue100,
+      labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
+      labelColor: theme.colors.blue100,
+      labelTop: SHRINKED_LABEL_TOP,
+      inputTextColor: theme.colors.white100,
+    },
+  }
 }
 
-const ERROR_VARIANT_STATES: VariantState = {
-  // Unfocused error input with no value
-  untouched: {
-    inputBorderColor: THEME.colors.red100,
-    labelFontSize: parseInt(THEME.textVariants["sm-display"].fontSize, 10),
-    labelColor: THEME.colors.red100,
-    labelTop: EXPANDED_LABEL_TOP,
-    inputTextColor: THEME.colors.black100,
-  },
-  // Unfocused error input with value
-  touched: {
-    inputBorderColor: THEME.colors.red100,
-    labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
-    labelColor: THEME.colors.red100,
-    labelTop: SHRINKED_LABEL_TOP,
-    inputTextColor: THEME.colors.black100,
-  },
-  // Focused error input with or without value
-  focused: {
-    inputBorderColor: THEME.colors.red100,
-    labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
-    labelColor: THEME.colors.red100,
-    labelTop: SHRINKED_LABEL_TOP,
-    inputTextColor: THEME.colors.black100,
-  },
+const getErrorVariantStates = (theme: ThemeType | ThemeWithDarkModeType): VariantState => {
+  return {
+    // Unfocused error input with no value
+    untouched: {
+      inputBorderColor: theme.colors.red100,
+      labelFontSize: parseInt(THEME.textVariants["sm-display"].fontSize, 10),
+      labelColor: theme.colors.red100,
+      labelTop: EXPANDED_LABEL_TOP,
+      inputTextColor: theme.colors.black100,
+    },
+    // Unfocused error input with value
+    touched: {
+      inputBorderColor: theme.colors.red100,
+      labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
+      labelColor: theme.colors.red100,
+      labelTop: SHRINKED_LABEL_TOP,
+      inputTextColor: theme.colors.black100,
+    },
+    // Focused error input with or without value
+    focused: {
+      inputBorderColor: theme.colors.red100,
+      labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
+      labelColor: theme.colors.red100,
+      labelTop: SHRINKED_LABEL_TOP,
+      inputTextColor: theme.colors.black100,
+    },
+  }
 }
 
-const DISABLED_VARIANT_STATES: VariantState = {
-  // Unfocused disabled input with no value
-  untouched: {
-    inputBorderColor: THEME.colors.black30,
-    labelFontSize: parseInt(THEME.textVariants["sm-display"].fontSize, 10),
-    labelColor: THEME.colors.black30,
-    labelTop: EXPANDED_LABEL_TOP,
-    inputTextColor: THEME.colors.black30,
-  },
-  // Unfocused disabled input with value
-  touched: {
-    inputBorderColor: THEME.colors.black30,
-    labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
-    labelColor: THEME.colors.black30,
-    labelTop: SHRINKED_LABEL_TOP,
-    inputTextColor: THEME.colors.black30,
-  },
-  // Focused disabled input with or without value
-  // Adding this just to satisfy typescript because a disabled input can't be focused
-  focused: {
-    inputBorderColor: THEME.colors.black30,
-    labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
-    labelColor: THEME.colors.black30,
-    labelTop: SHRINKED_LABEL_TOP,
-    inputTextColor: THEME.colors.black30,
-  },
+const getDisabledVariantStates = (theme: ThemeType | ThemeWithDarkModeType): VariantState => {
+  return {
+    // Unfocused disabled input with no value
+    untouched: {
+      inputBorderColor: theme.colors.black30,
+      labelFontSize: parseInt(THEME.textVariants["sm-display"].fontSize, 10),
+      labelColor: theme.colors.black30,
+      labelTop: EXPANDED_LABEL_TOP,
+      inputTextColor: theme.colors.black30,
+    },
+    // Unfocused disabled input with value
+    touched: {
+      inputBorderColor: theme.colors.black30,
+      labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
+      labelColor: theme.colors.black30,
+      labelTop: SHRINKED_LABEL_TOP,
+      inputTextColor: theme.colors.black30,
+    },
+    // Focused disabled input with or without value
+    // Adding this just to satisfy typescript because a disabled input can't be focused
+    focused: {
+      inputBorderColor: theme.colors.black30,
+      labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
+      labelColor: theme.colors.black30,
+      labelTop: SHRINKED_LABEL_TOP,
+      inputTextColor: theme.colors.black30,
+    },
+  }
 }
 
-export const INPUT_VARIANTS = {
-  default: DEFAULT_VARIANT_STATES,
-  error: ERROR_VARIANT_STATES,
-  disabled: DISABLED_VARIANT_STATES,
+export const getInputVariants = (theme: ThemeType | ThemeWithDarkModeType) => {
+  return {
+    default: getDefaultVariantStates(theme),
+    error: getErrorVariantStates(theme),
+    disabled: getDisabledVariantStates(theme),
+  }
 }
 
-export type InputState = keyof typeof DEFAULT_VARIANT_STATES
-export type InputVariant = keyof typeof INPUT_VARIANTS
+export type InputState = keyof ReturnType<typeof getDefaultVariantStates>
+export type InputVariant = keyof ReturnType<typeof getInputVariants>
 
 export const getInputState = ({
   isFocused,


### PR DESCRIPTION
### Description

This PR fixes the input component dark mode issues on Folio.

**What changes does this PR do?**
Instead of setting input color and border as hard coded values, this PR makes them dynamic. That's it

<img src="https://github.com/user-attachments/assets/39925200-e7e5-4f22-9034-0602f4f5539e" width="400" />

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>14.0.23--canary.305.3162.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@14.0.23--canary.305.3162.0
  # or 
  yarn add @artsy/palette-mobile@14.0.23--canary.305.3162.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
