### PR TITLE
fix: default color for inputs

### DIFF
--- a/src/elements/Input/helpers.ts
+++ b/src/elements/Input/helpers.ts
@@ -36,7 +36,7 @@ const getDefaultVariantStates = (theme: ThemeType | ThemeWithDarkModeType): Vari
       labelFontSize: parseInt(THEME.textVariants["sm-display"].fontSize, 10),
       labelColor: theme.colors.black60,
       labelTop: EXPANDED_LABEL_TOP,
-      inputTextColor: theme.colors.white100,
+      inputTextColor: theme.colors.black100,
     },
     // Unfocused input with value
     touched: {
@@ -44,7 +44,7 @@ const getDefaultVariantStates = (theme: ThemeType | ThemeWithDarkModeType): Vari
       labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
       labelColor: theme.colors.black60,
       labelTop: SHRINKED_LABEL_TOP,
-      inputTextColor: theme.colors.white100,
+      inputTextColor: theme.colors.black100,
     },
     // Focused input with or without value
     focused: {
@@ -52,7 +52,7 @@ const getDefaultVariantStates = (theme: ThemeType | ThemeWithDarkModeType): Vari
       labelFontSize: parseInt(THEME.textVariants.xs.fontSize, 10),
       labelColor: theme.colors.blue100,
       labelTop: SHRINKED_LABEL_TOP,
-      inputTextColor: theme.colors.white100,
+      inputTextColor: theme.colors.black100,
     },
   }
 }


### PR DESCRIPTION
This PR resolves https://artsy.slack.com/archives/C02BAQ5K7/p1739444115801439

### Description
<img width="1389" alt="Screenshot 2025-02-13 at 14 19 06" src="https://github.com/user-attachments/assets/91df7cc7-e139-405d-9460-573cf9f01ce7" />

Fix the default color for inputs.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
