### PR TITLE
fix: Replace TouchableHighlight with TouchableOpacity in Touchable

### DIFF
--- a/src/elements/Touchable/Touchable.tsx
+++ b/src/elements/Touchable/Touchable.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 import {
   GestureResponderEvent,
-  TouchableHighlight,
   TouchableHighlightProps,
+  TouchableOpacity,
   TouchableWithoutFeedback,
 } from "react-native"
 import Haptic, { HapticFeedbackTypes } from "react-native-haptic-feedback"
@@ -57,13 +57,8 @@ export const Touchable: React.FC<TouchableProps> = ({
       {inner}
     </TouchableWithoutFeedback>
   ) : (
-    <TouchableHighlight
-      underlayColor={underlayColor ?? "transparent"}
-      activeOpacity={DEFAULT_ACTIVE_OPACITY}
-      {...props}
-      onPress={onPressWrapped}
-    >
+    <TouchableOpacity activeOpacity={DEFAULT_ACTIVE_OPACITY} {...props} onPress={onPressWrapped}>
       {inner}
-    </TouchableHighlight>
+    </TouchableOpacity>
   )
 }


### PR DESCRIPTION
This PR resolves [ONYX-1517] <!-- eg [PROJECT-XXXX] -->

* Related PR: https://github.com/artsy/eigen/pull/11499

## Description

While replacing touchable components with the new [RouterLink](https://github.com/artsy/eigen/blob/a1b585ff4a84ac87ff474959c050cf338e63985c/src/app/system/navigation/RouterLink.tsx#L24), I discovered that Palette's `Touchable` component (which isn't widely used in the app) only works in some cases.

This PR replaces [TouchableHighlight](https://reactnative.dev/docs/touchablehighlight) with [TouchableOpacity](https://reactnative.dev/docs/touchableopacity) in the `Touchable` component. The difference is marginal, but `TouchableHighlight` does not work with images (see videos).

### Follow-Up

Use Palette's `Touchable` component in Eigen's `RouterLink`. 

## Videos / Screenshots

**Before:**

Images aren't responding to touch.

https://github.com/user-attachments/assets/561249cc-bf93-43db-9f82-934c0e26adc7

**After:**

https://github.com/user-attachments/assets/47d9a91c-559f-4679-a940-6316c2f007ef



[ONYX-1517]: https://artsyproduct.atlassian.net/browse/ONYX-1517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ