### PR TITLE
feat(ONYX-1606): add largeTitle prop to StickySubHeader

### DIFF
--- a/src/elements/Screen/Screen.stories.tsx
+++ b/src/elements/Screen/Screen.stories.tsx
@@ -198,11 +198,11 @@ storiesOf("Screen", module)
     </Screen>
   ))
 
-  .add("FlatList With AnimatedHeader and XL StickySubHeader", () => (
+  .add("FlatList With AnimatedHeader and large StickySubHeader", () => (
     <Screen>
       <Screen.AnimatedHeader title="Title" />
 
-      <Screen.StickySubHeader title="Title" titleVariant="xl">
+      <Screen.StickySubHeader title="Title" largeTitle>
         <Flex width="100%" height={60} backgroundColor="red10" />
       </Screen.StickySubHeader>
 

--- a/src/elements/Screen/Screen.stories.tsx
+++ b/src/elements/Screen/Screen.stories.tsx
@@ -198,6 +198,29 @@ storiesOf("Screen", module)
     </Screen>
   ))
 
+  .add("FlatList With AnimatedHeader and XL StickySubHeader", () => (
+    <Screen>
+      <Screen.AnimatedHeader title="Title" />
+
+      <Screen.StickySubHeader title="Title" titleVariant="xl">
+        <Flex width="100%" height={60} backgroundColor="red10" />
+      </Screen.StickySubHeader>
+
+      <Screen.Body>
+        <Screen.FlatList
+          data={Array.from({ length: 50 }).map((_, i) => "Item " + i)}
+          renderItem={({ item, index }) => {
+            return (
+              <Text my={1} key={index}>
+                {item}
+              </Text>
+            )
+          }}
+        />
+      </Screen.Body>
+    </Screen>
+  ))
+
   .add("Fullwidth", () => (
     <Screen>
       <Screen.Header title="Title" />

--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -1,3 +1,4 @@
+import { TextVariant } from "@artsy/palette-tokens/dist/typography/v3"
 import { useState } from "react"
 import { LayoutChangeEvent } from "react-native"
 import Animated, { useAnimatedStyle, useDerivedValue, withTiming } from "react-native-reanimated"
@@ -10,6 +11,7 @@ import { Text } from "../Text"
 
 export interface StickySubHeaderProps extends React.PropsWithChildren<{}> {
   title: string
+  titleVariant?: TextVariant
   separatorComponent?: React.ReactNode
   subTitle?: string
   Component?: React.ReactNode
@@ -20,6 +22,7 @@ const DEFAULT_SEPARATOR_COMPONENT = <Separator borderColor="black5" />
 
 export const StickySubHeader: React.FC<StickySubHeaderProps> = ({
   title,
+  titleVariant = "lg-display",
   separatorComponent = DEFAULT_SEPARATOR_COMPONENT,
   subTitle,
   children,
@@ -73,7 +76,7 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({
           style={sharedStyles}
         >
           <Flex mb={1}>
-            <Text variant="lg-display" color="white100">
+            <Text variant={titleVariant} color="white100">
               {title}
             </Text>
             {!!subTitle && (
@@ -89,7 +92,7 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({
       <Animated.View style={[sharedStyles, animatedStyles]}>
         {/* If we don't specify a height for the text, we will get text jumps as the parent component height changes  */}
         <Flex style={{ height: stickyBarHeight }} mb={1}>
-          <Text variant="lg-display">{title}</Text>
+          <Text variant={titleVariant}>{title}</Text>
           {subTitle && (
             <Text variant="xs" mt={0.5}>
               {subTitle}

--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -1,4 +1,3 @@
-import { TextVariant } from "@artsy/palette-tokens/dist/typography/v3"
 import { useState } from "react"
 import { LayoutChangeEvent } from "react-native"
 import Animated, { useAnimatedStyle, useDerivedValue, withTiming } from "react-native-reanimated"
@@ -11,6 +10,9 @@ import { Text } from "../Text"
 
 export interface StickySubHeaderProps extends React.PropsWithChildren<{}> {
   title: string
+  /**
+   * largeTitle will make the title use the `xl` variant;
+   */
   largeTitle?: boolean
   separatorComponent?: React.ReactNode
   subTitle?: string

--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -11,7 +11,7 @@ import { Text } from "../Text"
 
 export interface StickySubHeaderProps extends React.PropsWithChildren<{}> {
   title: string
-  titleVariant?: TextVariant
+  largeTitle?: boolean
   separatorComponent?: React.ReactNode
   subTitle?: string
   Component?: React.ReactNode
@@ -22,7 +22,7 @@ const DEFAULT_SEPARATOR_COMPONENT = <Separator borderColor="black5" />
 
 export const StickySubHeader: React.FC<StickySubHeaderProps> = ({
   title,
-  titleVariant = "lg-display",
+  largeTitle = false,
   separatorComponent = DEFAULT_SEPARATOR_COMPONENT,
   subTitle,
   children,
@@ -76,7 +76,7 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({
           style={sharedStyles}
         >
           <Flex mb={1}>
-            <Text variant={titleVariant} color="white100">
+            <Text variant={largeTitle ? "xl" : "lg-display"} color="white100">
               {title}
             </Text>
             {!!subTitle && (
@@ -92,7 +92,7 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({
       <Animated.View style={[sharedStyles, animatedStyles]}>
         {/* If we don't specify a height for the text, we will get text jumps as the parent component height changes  */}
         <Flex style={{ height: stickyBarHeight }} mb={1}>
-          <Text variant={titleVariant}>{title}</Text>
+          <Text variant={largeTitle ? "xl" : "lg-display"}>{title}</Text>
           {subTitle && (
             <Text variant="xs" mt={0.5}>
               {subTitle}


### PR DESCRIPTION
This PR resolves [ONYX-1606] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Add largeTitle prop to StickySubHeader
https://artsy.slack.com/archives/C05EQL4R5N0/p1742206684262199

| iOS | Android |
| --- | --- |
| <img width="352" alt="image" src="https://github.com/user-attachments/assets/e9bf01b7-e52b-4d21-9a65-8dc120169569" />  | <img width="352" alt="image" src="https://github.com/user-attachments/assets/d7762297-9139-46e0-bd02-9695c1f74f8d" /> |

[ONYX-1606]: https://artsyproduct.atlassian.net/browse/ONYX-1606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ