### PR TITLE
fix(Input): Input reset values on Android

### DIFF
--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -317,7 +317,7 @@ export const Input = forwardRef<InputRef, InputProps>(
       }
     }, [fontFamily, space, color])
 
-    const inputVariants = useMemo(() => getInputVariants(theme), [])
+    const inputVariants = useMemo(() => getInputVariants(theme), [theme])
 
     useEffect(() => {
       const inputState = getInputState({


### PR DESCRIPTION
### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

#305 introduced some regressions when you type on Android the input text gets flushed out. This PR adds a bandaid for that. 

I'd ask the reviewers to test on iPhone and Android if possible please 🙇 

Before:
 
https://github.com/user-attachments/assets/69327ec9-5804-412d-893c-438a36ba5a3f

After:

https://github.com/user-attachments/assets/5ce69c04-3188-4484-94f2-58429be333a8




