### PR TITLE
fix: remove skeleton text on android devices

### DIFF
--- a/src/elements/Skeleton/Skeleton.tsx
+++ b/src/elements/Skeleton/Skeleton.tsx
@@ -39,7 +39,7 @@ export const SkeletonText: FC<TextProps> = ({ children, ...rest }) => {
 
   return (
     <Flex alignSelf="flex-start">
-      <Text {...rest} bg={color("black10")} color={color("black10")}>
+      <Text {...rest} bg={color("black10")} color="transparent">
         {children}
       </Text>
     </Flex>


### PR DESCRIPTION
This PR resolves [PBRW-395] <!-- eg [PROJECT-XXXX] -->

### Description

Removes text from android skeletons 

#### Android

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/a0c8136d-0990-4eb2-b37d-ab88fad2a6a1" width="300" />|<video src="https://github.com/user-attachments/assets/ce428e00-92e1-4c50-96c3-e41acc61f336" width="300" />|

Stories:

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/dc945081-f886-4037-9235-931a23a47df7" width="300" />|<video src="https://github.com/user-attachments/assets/d390a70d-f010-4776-85cb-79f5e5f2444d" width="300" />|

#### iOS

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/a15d2ff1-0d20-4ac2-80c6-083b6d92bf18" width="300" />|<video src="https://github.com/user-attachments/assets/a15d2ff1-0d20-4ac2-80c6-083b6d92bf18" width="300" />|










<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[PBRW-395]: https://artsyproduct.atlassian.net/browse/PBRW-395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ