### PR TITLE
fix: Increase dark mode onBackgroundMedium to increase contrast

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -115,7 +115,7 @@ const v3dark: ThemeWithDarkModeType = {
     background: THEME_DARK.colors.white100,
     onBackground: THEME_DARK.colors.black100,
     onBackgroundHigh: THEME_DARK.colors.black100,
-    onBackgroundMedium: THEME_DARK.colors.black30,
+    onBackgroundMedium: THEME_DARK.colors.black60,
     onBackgroundLow: THEME_DARK.colors.black60,
     surface: "#333",
     onSurface: THEME_DARK.colors.white100,


### PR DESCRIPTION
Resolves [Notion-Several-cases-of...](https://www.notion.so/artsy/Several-cases-of-type-that-has-low-bg-contrast-and-that-likely-don-t-meet-accessibility-guidelines-1a1cab0764a0808c97c6e5894678a40e?pvs=4) <!-- eg [PROJECT-XXXX] -->

* Related Eigen PR: https://github.com/artsy/eigen/pull/11851

### Description

This increases dark mode `onBackgroundMedium` color to increase text contrast (black30 -> black60).

| Before | After |
| --- | --- |
|![Simulator Screenshot - iPhone 16 - 2025-04-07 at 13 02 47](https://github.com/user-attachments/assets/b70e4cc7-fd57-4104-85f9-55dff57f81ee) | ![Simulator Screenshot - iPhone 16 - 2025-04-07 at 13 04 33](https://github.com/user-attachments/assets/2f5d02b3-c9f4-4762-bb24-555717700e26)|







