### PR TITLE
fix: Increase contrast for onBackgroundMedium dark theme color

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -115,7 +115,7 @@ const v3dark: ThemeWithDarkModeType = {
     background: THEME_DARK.colors.white100,
     onBackground: THEME_DARK.colors.black100,
     onBackgroundHigh: THEME_DARK.colors.black100,
-    onBackgroundMedium: THEME_DARK.colors.black60,
+    onBackgroundMedium: THEME_DARK.colors.black100,
     onBackgroundLow: THEME_DARK.colors.black60,
     surface: "#333",
     onSurface: THEME_DARK.colors.white100,


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

Increase `onBackgroundMedium` dark theme color for the app. This will increase the contrast for tab title color for non-active tabs.

### Screenshots (increased non-active tab title color)

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone 16 - 2025-04-14 at 11 34 57](https://github.com/user-attachments/assets/d1313dc9-cd5a-4da2-baed-b0ebae93191b)|![Simulator Screenshot - iPhone 16 - 2025-04-14 at 11 35 40](https://github.com/user-attachments/assets/3cb61c57-059a-449b-94f0-22cf58af5872) |

