### PR TITLE
chore: remove duplicate auto-release plugins

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -1,8 +1,6 @@
 {
   "extends": "@artsy",
   "plugins": [
-    "npm",
-    "first-time-contributor",
-    "released"
+    "first-time-contributor"
   ]
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR attempts to fix an issue where we had a double release in the previous PR (#332)

I believe the double release happened because we have duplicate plugins for releasing in [.autorc](https://github.com/artsy/palette-mobile/blob/main/.autorc#L4) and in [@artsy/auto-config](https://github.com/artsy/auto-config/blob/main/package.json#L51), which called the commands to release twice, causing the double release issue

This is an attempt to fix it