### PR TITLE
fix: chevron icon component

### DIFF
--- a/src/svgs/ChevronIcon.tsx
+++ b/src/svgs/ChevronIcon.tsx
@@ -1,16 +1,65 @@
-import { ArrowDownIcon } from "./ArrowDownIcon"
-import { ArrowLeftIcon } from "./ArrowLeftIcon"
-import { ArrowRightIcon } from "./ArrowRightIcon"
-import { ArrowUpIcon } from "./ArrowUpIcon"
-import { IconProps } from "./Icon"
+import { Icon, IconProps, Path } from "./Icon"
+import { useColor } from "../utils/hooks"
 
 type Direction = "left" | "right" | "up" | "down"
 
+export const ChevronRightIcon = ({ fill = "mono100", ...restProps }: IconProps) => {
+  const color = useColor()
+  return (
+    <Icon {...restProps} viewBox="0 0 18 18">
+      <Path
+        d="M6.62132 3L12.5 9L6.62132 15L5.5 13.8555L10.2574 9L5.5 4.14446L6.62132 3Z"
+        fill={color(fill)}
+        fillRule="nonzero"
+      />
+    </Icon>
+  )
+}
+
+export const ChevronUpIcon = ({ fill = "mono100", ...restProps }: IconProps) => {
+  const color = useColor()
+  return (
+    <Icon {...restProps} viewBox="0 0 18 18">
+      <Path
+        d="M3 11.3787L9 5.5L15 11.3787L13.8555 12.5L9 7.74264L4.14446 12.5L3 11.3787Z"
+        fill={color(fill)}
+        fillRule="nonzero"
+      />
+    </Icon>
+  )
+}
+
+export const ChevronLeftIcon = ({ fill = "mono100", ...restProps }: IconProps) => {
+  const color = useColor()
+  return (
+    <Icon {...restProps} viewBox="0 0 18 18">
+      <Path
+        d="M11.3787 15L5.5 9L11.3787 3L12.5 4.14446L7.74264 9L12.5 13.8555L11.3787 15Z"
+        fill={color(fill)}
+        fillRule="nonzero"
+      />
+    </Icon>
+  )
+}
+
+export const ChevronDownIcon = ({ fill = "mono100", ...restProps }: IconProps) => {
+  const color = useColor()
+  return (
+    <Icon {...restProps} viewBox="0 0 18 18">
+      <Path
+        d="M15 6.62132L9 12.5L3 6.62132L4.14446 5.5L9 10.2574L13.8555 5.5L15 6.62132Z"
+        fill={color(fill)}
+        fillRule="nonzero"
+      />
+    </Icon>
+  )
+}
+
 const directionMap = {
-  left: ArrowLeftIcon,
-  right: ArrowRightIcon,
-  up: ArrowUpIcon,
-  down: ArrowDownIcon,
+  left: ChevronLeftIcon,
+  right: ChevronRightIcon,
+  up: ChevronUpIcon,
+  down: ChevronDownIcon,
 }
 
 interface ChevronProps extends IconProps {


### PR DESCRIPTION
This PR resolves [ONYX-1693] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes an issue with the chevron icon.

The implementation of the chevron icon was using wrong icons, instead of using separate svgs, we were using the arrow icon svgs. The latters are thinner and wider.

**Before**
<img width="287" alt="Screenshot 2025-04-23 at 12 35 02" src="https://github.com/user-attachments/assets/54dd8b85-6688-4cb2-8c20-95f3ac4bb421" />

**After**
<img width="281" alt="Screenshot 2025-04-23 at 12 35 05" src="https://github.com/user-attachments/assets/e4af49ac-ecbf-4aac-90fe-6b129bbe3897" />



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[ONYX-1693]: https://artsyproduct.atlassian.net/browse/ONYX-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ