### PR TITLE
fix: Info message component contrast ratio

### DIFF
--- a/src/elements/Message/Message.tsx
+++ b/src/elements/Message/Message.tsx
@@ -138,10 +138,8 @@ const colors: Record<
   },
   info: {
     background: "blue10",
-    title: "blue100",
-    // The text should be black regardless of the theme
-    // @ts-expect-error
-    text: "black",
+    title: "blue150",
+    text: "mono100",
     icon: "mono100",
   },
   success: {


### PR DESCRIPTION
This PR resolves [ONYX-1694] <!-- eg [PROJECT-XXXX] -->

### Description

The background of the info message seems to be too light (blue10) in dark mode, and the title contrast ratio isn’t good enough. We need to make the title a bit lighter and the background darker.

This PR aligns the text color with other message variants (using `blue150` instead of `blue100` for a higher contrast ratio).


**Message Components:**



| Before | After |
| --- | --- |
|![Simulator Screenshot - iPhone 16 - 2025-04-24 at 10 20 54](https://github.com/user-attachments/assets/559408c9-b51d-464a-8be6-b29021f6c8f9) |![Simulator Screenshot - iPhone 16 - 2025-04-24 at 10 20 43](https://github.com/user-attachments/assets/f2666aa1-577b-4fb0-8d53-d2998459a75e) |

| Before | After |
| --- | --- |
 ![Simulator Screenshot - iPhone 16 - 2025-04-24 at 10 52 48](https://github.com/user-attachments/assets/79b084c4-4f4f-40ce-a1c5-89029075348e) | ![Simulator Screenshot - iPhone 16 - 2025-04-24 at 10 52 30](https://github.com/user-attachments/assets/1c2e18ed-c1e2-4c8c-9dbc-2bf2f57e85be) |





**Contrast Ratio (after):**

| Dark | Light |
| --- | --- |
|<img width="1230" alt="Bildschirmfoto 2025-04-24 um 10 34 01" src="https://github.com/user-attachments/assets/d9245780-fce2-480b-a928-7ecbfea2eebe" /> |<img width="772" alt="Bildschirmfoto 2025-04-24 um 10 51 03" src="https://github.com/user-attachments/assets/cf4d668d-7a9a-44c6-aa14-8e50f4c4ae55" /> |





[ONYX-1694]: https://artsyproduct.atlassian.net/browse/ONYX-1694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ