### PR TITLE
chore: increase spacing below subtitle title

### DIFF
--- a/src/elements/Screen/StickySubHeader.tsx
+++ b/src/elements/Screen/StickySubHeader.tsx
@@ -71,7 +71,7 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({
           zIndex={-1000}
           style={sharedStyles}
         >
-          <Flex mb={1}>
+          <Flex mb={2}>
             <Text variant={largeTitle ? "xl" : "lg-display"} color="mono0">
               {title}
             </Text>
@@ -87,7 +87,7 @@ export const StickySubHeader: React.FC<StickySubHeaderProps> = ({
 
       <Animated.View style={[sharedStyles, animatedStyles]}>
         {/* If we don't specify a height for the text, we will get text jumps as the parent component height changes  */}
-        <Flex style={{ height: stickyBarHeight }} mb={1}>
+        <Flex style={{ height: stickyBarHeight }} mb={2}>
           <Text variant={largeTitle ? "xl" : "lg-display"}>{title}</Text>
           {subTitle && (
             <Text variant="xs" mt={0.5}>


### PR DESCRIPTION
This PR resolves https://www.figma.com/design/Z9legdjhKORHt0vOGpvBg3/App%E2%80%A8IA-and-Shortcuts?node-id=3132-64319&p=f&m=dev

### Description

This PR increases the bottom margin below the sticky header title.

<img width="584" alt="Screenshot 2025-04-24 at 15 07 23" src="https://github.com/user-attachments/assets/95eebc3b-ca32-442c-824f-bfd29568074d" />

