### PR TITLE
fix: Set Pill selected text color to theme-independent white

### DIFF
--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -202,7 +202,8 @@ const PILL_VARIANTS: Record<PillVariant, Record<PillState, FlattenInterpolation<
 
 const defaultColors: Record<PillState, Color> = {
   default: "mono100",
-  selected: "mono0",
+  // @ts-expect-error We want to set the color to white here regardless of the theme
+  selected: "white",
   disabled: "mono60",
 }
 const TEXT_COLOR: Record<PillVariant, Record<PillState, Color>> = {


### PR DESCRIPTION
Follow up for https://github.com/artsy/palette-mobile/pull/337 & [ <!-- eg [PROJECT-XXXX] -->](https://github.com/artsy/eigen/pull/11985)

### Description

Set Pill selected text color to theme-independent white.
