### PR TITLE
feat: support pill tabs

### DIFF
--- a/src/elements/Tabs/TabsContainer.tsx
+++ b/src/elements/Tabs/TabsContainer.tsx
@@ -1,3 +1,5 @@
+import { debounce } from "lodash"
+import { useState } from "react"
 import { Platform } from "react-native"
 import {
   Tabs as BaseTabs,
@@ -6,11 +8,13 @@ import {
   MaterialTabItem,
   TabItemProps,
 } from "react-native-collapsible-tab-view"
+import { runOnJS, useAnimatedReaction } from "react-native-reanimated"
 import { DEFAULT_ACTIVE_OPACITY } from "../../constants"
 import { useColor } from "../../utils/hooks/useColor"
 import { useSpace } from "../../utils/hooks/useSpace"
 import { Box } from "../Box"
 import { Flex } from "../Flex"
+import { Pill } from "../Pill"
 
 const TAB_BAR_HEIGHT = 50
 
@@ -19,21 +23,77 @@ interface Indicator {
   Component: React.FC<TabItemProps<string>>
 }
 
+interface PillTabItemProps extends TabItemProps<string> {
+  onTabPress?: (tabName: string) => void
+  focusedTab: { value: string }
+}
+
+const PillTabItem: React.FC<PillTabItemProps> = (props) => {
+  const [focusedTab, setFocusedTab] = useState(props.focusedTab.value)
+
+  // We want to debounce the focusedTab value to avoid showing two pills at once
+  const debouncedFocusedTab = debounce(setFocusedTab, 30)
+
+  useAnimatedReaction(
+    () => props.focusedTab.value,
+    (value) => {
+      runOnJS(debouncedFocusedTab)(value)
+    }
+  )
+
+  return (
+    <Pill
+      selected={props.name === focusedTab}
+      onPress={() => {
+        props.onTabPress?.(props.name)
+      }}
+      key={props.name}
+      variant="link"
+    >
+      {props.name}
+    </Pill>
+  )
+}
+
+interface DefaultTabItemProps extends TabItemProps<string> {
+  indicators: Indicator[]
+  onPress: (name: string) => void
+}
+
+const DefaultTabItem: React.FC<DefaultTabItemProps> = (props) => {
+  const Indicator = props.indicators.find((indicator) => {
+    return indicator.tabName === props.name
+  })
+
+  return (
+    <Box flex={1}>
+      <Flex position="absolute" width="100%">
+        {!!Indicator?.Component && <Indicator.Component {...props} />}
+      </Flex>
+      <MaterialTabItem pressOpacity={DEFAULT_ACTIVE_OPACITY} {...props} onPress={props.onPress} />
+    </Box>
+  )
+}
+
 export interface TabsContainerProps extends CollapsibleProps {
   indicators?: Indicator[]
   // This prop is more immediate than onTabChange, which waits till the
   // transition takes place
   onTabPress?: (tabName: string) => void
+  stickyTabBarComponent?: React.ReactNode
   tabScrollEnabled?: boolean
+  usePills?: boolean
 }
 
 export const TabsContainer: React.FC<TabsContainerProps> = ({
   children,
   indicators = [],
   initialTabName,
-  renderHeader,
-  tabScrollEnabled = false,
   onTabPress,
+  renderHeader,
+  stickyTabBarComponent,
+  tabScrollEnabled = false,
+  usePills = false,
   ...tabContainerProps
 }) => {
   const space = useSpace()
@@ -43,7 +103,6 @@ export const TabsContainer: React.FC<TabsContainerProps> = ({
 
   return (
     <BaseTabs.Container
-      {...tabContainerProps}
       renderHeader={renderHeader}
       headerContainerStyle={{
         shadowOpacity: 0,
@@ -56,6 +115,34 @@ export const TabsContainer: React.FC<TabsContainerProps> = ({
         paddingTop: space(2),
       }}
       renderTabBar={(tabBarProps) => {
+        if (usePills) {
+          return (
+            <Flex flexDirection="row" gap={2} alignItems="center" py={1}>
+              <MaterialTabBar
+                {...tabBarProps}
+                scrollEnabled
+                TabItemComponent={(props) => (
+                  <PillTabItem
+                    {...props}
+                    onTabPress={(tab) => {
+                      onTabPress?.(tab)
+                      tabBarProps.onTabPress(tab)
+                    }}
+                    focusedTab={tabBarProps.focusedTab}
+                  />
+                )}
+                indicatorStyle={{
+                  backgroundColor: "transparent",
+                }}
+                contentContainerStyle={{
+                  gap: space(1),
+                  paddingHorizontal: space(2),
+                }}
+              />
+              {stickyTabBarComponent}
+            </Flex>
+          )
+        }
         return (
           <>
             <MaterialTabBar
@@ -70,24 +157,11 @@ export const TabsContainer: React.FC<TabsContainerProps> = ({
                 borderBottomWidth: 1,
                 borderColor: color("mono30"),
               }}
-              TabItemComponent={(props) => {
-                const Indicator = indicators.find((indicator) => {
-                  return indicator.tabName === props.name
-                })
-
-                return (
-                  <Box flex={1}>
-                    <Flex position="absolute" width="100%">
-                      {!!Indicator?.Component && <Indicator.Component {...props} />}
-                    </Flex>
-                    <MaterialTabItem pressOpacity={DEFAULT_ACTIVE_OPACITY} {...props} />
-                  </Box>
-                )
-              }}
+              TabItemComponent={(props) => <DefaultTabItem {...props} indicators={indicators} />}
               contentContainerStyle={{}}
               activeColor={color("onBackground")}
               inactiveColor={color("onBackgroundMedium")}
-              labelStyle={{ marginHorizontal: 0 }} // removing the horizonal margin from the lib
+              labelStyle={{ marginHorizontal: 0 }} // removing the horizontal margin from the lib
               indicatorStyle={{
                 backgroundColor: color("onBackground"),
                 height: 1,
@@ -103,6 +177,7 @@ export const TabsContainer: React.FC<TabsContainerProps> = ({
           </>
         )
       }}
+      {...tabContainerProps}
     >
       {children}
     </BaseTabs.Container>

--- a/src/elements/Tabs/TabsContainer.tsx
+++ b/src/elements/Tabs/TabsContainer.tsx
@@ -28,14 +28,14 @@ interface PillTabItemProps extends TabItemProps<string> {
   focusedTab: { value: string }
 }
 
-const PillTabItem: React.FC<PillTabItemProps> = (props) => {
-  const [focusedTab, setFocusedTab] = useState(props.focusedTab.value)
+const PillTabItem: React.FC<PillTabItemProps> = ({ focusedTab: focusedTabProp, ...props }) => {
+  const [focusedTab, setFocusedTab] = useState(focusedTabProp.value)
 
   // We want to debounce the focusedTab value to avoid showing two pills at once
   const debouncedFocusedTab = debounce(setFocusedTab, 30)
 
   useAnimatedReaction(
-    () => props.focusedTab.value,
+    () => focusedTabProp.value,
     (value) => {
       runOnJS(debouncedFocusedTab)(value)
     }
@@ -70,7 +70,7 @@ const DefaultTabItem: React.FC<DefaultTabItemProps> = (props) => {
       <Flex position="absolute" width="100%">
         {!!Indicator?.Component && <Indicator.Component {...props} />}
       </Flex>
-      <MaterialTabItem pressOpacity={DEFAULT_ACTIVE_OPACITY} {...props} onPress={props.onPress} />
+      <MaterialTabItem pressOpacity={DEFAULT_ACTIVE_OPACITY} {...props} />
     </Box>
   )
 }
@@ -82,7 +82,7 @@ export interface TabsContainerProps extends CollapsibleProps {
   onTabPress?: (tabName: string) => void
   stickyTabBarComponent?: React.ReactNode
   tabScrollEnabled?: boolean
-  usePills?: boolean
+  variant?: "pills" | "tabs"
 }
 
 export const TabsContainer: React.FC<TabsContainerProps> = ({
@@ -93,7 +93,7 @@ export const TabsContainer: React.FC<TabsContainerProps> = ({
   renderHeader,
   stickyTabBarComponent,
   tabScrollEnabled = false,
-  usePills = false,
+  variant = "tabs",
   ...tabContainerProps
 }) => {
   const space = useSpace()
@@ -115,7 +115,7 @@ export const TabsContainer: React.FC<TabsContainerProps> = ({
         paddingTop: space(2),
       }}
       renderTabBar={(tabBarProps) => {
-        if (usePills) {
+        if (variant === "pills") {
           return (
             <Flex flexDirection="row" gap={2} alignItems="center" py={1}>
               <MaterialTabBar


### PR DESCRIPTION
This PR resolves [ONYX-1676] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds support of:
- Pills instead of tabs inside Tabs.
```typescript
<Tabs
  renderHeader={MyCollectionCollectorProfileHeader}
  onTabPress={(tab) => {
    setActiveNavigationTab(tab as MyCollectionNavigationTab)
  }}
  ...
  usePills // 👈👈👈 new prop
>
```
- Using a sticky button to the right of the pills
```typescript
<Tabs
  renderHeader={MyCollectionCollectorProfileHeader}
  headerHeight={500}
  pagerProps={{
    scrollEnabled: false,
  }}
  onTabPress={(tab) => {
    setActiveNavigationTab(tab as MyCollectionNavigationTab)
  }}
  usePills
  stickyTabBarComponent={ // 👈👈👈 new prop
    <Flex flexDirection="row" alignItems="center" gap={1} pr={2}>
      <Touchable hitSlop={ICON_HIT_SLOP} onPress={() => {}}>
        <FilterIcon height={DEFAULT_ICON_SIZE} width={DEFAULT_ICON_SIZE} />
      </Touchable>
      <Touchable hitSlop={ICON_HIT_SLOP} onPress={() => {}}>
        <AddIcon height={DEFAULT_ICON_SIZE} width={DEFAULT_ICON_SIZE} />
      </Touchable>
    </Flex>
  }
>
```

| iOS | Android |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/45f434fa-a62a-4a68-923d-4a4b41c3cd4a" /> | <video src="https://github.com/user-attachments/assets/9323dd22-9656-4c70-9eee-0f99692c20aa" /> | 


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[ONYX-1676]: https://artsyproduct.atlassian.net/browse/ONYX-1676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ