### PR TITLE
chore: remove figma link from palette

### DIFF
--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,7 +1,6 @@
 /**
- * All of the config for the Artsy theming system, based on the
- * design system from our design team:
- * https://www.figma.com/file/gZNkyqLT8AU3T61tluVJyB/Artsy-3.1-Design-System
+ * All of the config for the Artsy theming system are based on the
+ * on tokens from palette
  */
 
 import { THEME } from "@artsy/palette-tokens"


### PR DESCRIPTION
### Description

This PR removes palette figma link from our docs.

**Context:** https://artsy.slack.com/archives/CHVFQ06DV/p1745918628979609

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
