### PR TITLE
chore: increase debounce focued tab duration

### DIFF
--- a/src/elements/Tabs/TabsContainer.tsx
+++ b/src/elements/Tabs/TabsContainer.tsx
@@ -32,7 +32,7 @@ const PillTabItem: React.FC<PillTabItemProps> = ({ focusedTab: focusedTabProp, .
   const [focusedTab, setFocusedTab] = useState(focusedTabProp.value)
 
   // We want to debounce the focusedTab value to avoid showing two pills at once
-  const debouncedFocusedTab = debounce(setFocusedTab, 30)
+  const debouncedFocusedTab = debounce(setFocusedTab, 50)
 
   useAnimatedReaction(
     () => focusedTabProp.value,


### PR DESCRIPTION
This PR resolves https://www.notion.so/artsy/Tabs-changing-weirdly-1ebcab0764a080ab87acdc8ffe6f4649?pvs=4

### Description

This PR increases the debounce focused tab duration to make sure that we don't show the tab transition.


https://github.com/user-attachments/assets/466793bf-f629-44c1-ae1e-68db53390258



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
