### PR TITLE
feat: add accessibility roles and labels to various components for improved a11y

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -106,10 +106,5 @@ module.exports = {
       files: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)"],
       extends: ["plugin:testing-library/react"],
     },
-    {
-      // a11y plugin should ignore stories files
-      files: ["*.stories.*"],
-      extends: ["plugin:react-native-a11y/basic"],
-    },
   ],
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
   plugins: ["@typescript-eslint", "jest", "react-hooks", "testing-library"],
   extends: [
     "@react-native",
+    "plugin:react-native-a11y/basic",
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:@typescript-eslint/recommended",
@@ -97,12 +98,18 @@ module.exports = {
     "no-useless-escape": OFF,
     "react-native/no-inline-styles": OFF,
     "react/react-in-jsx-scope": OFF,
+    "react-native-a11y/has-accessibility-hint": OFF,
   },
   overrides: [
     {
       // Test files only
       files: ["**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)"],
       extends: ["plugin:testing-library/react"],
+    },
+    {
+      // a11y plugin should ignore stories files
+      files: ["*.stories.*"],
+      extends: ["plugin:react-native-a11y/basic"],
     },
   ],
 }

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-native-a11y": "^3.5.1",
     "eslint-plugin-storybook": "0.6.10",
     "eslint-plugin-testing-library": "6.4.0",
     "husky": "^8.0.3",

--- a/src/elements/BackButton/BackButton.tsx
+++ b/src/elements/BackButton/BackButton.tsx
@@ -47,7 +47,13 @@ export const BackButtonWithBackground: React.FC<BackButtonProps> = ({
   style,
 }) => {
   return (
-    <TouchableOpacity onPress={onPress} hitSlop={hitSlop}>
+    <TouchableOpacity
+      accessibilityRole="button"
+      accessibilityLabel={showX ? "Close" : "Back"}
+      accessibilityHint={showX ? "Closes the modal" : "Navigates to the previous screen"}
+      onPress={onPress}
+      hitSlop={hitSlop}
+    >
       <Flex
         backgroundColor="background"
         width={40}

--- a/src/elements/Banner/Banner.tsx
+++ b/src/elements/Banner/Banner.tsx
@@ -46,6 +46,7 @@ export const Banner = ({
 
   return (
     <Animated.View
+      accessibilityLabel="Banner"
       style={{
         height: tempHeight,
         transform: [
@@ -73,6 +74,9 @@ export const Banner = ({
           {!!dismissable && (
             <Flex>
               <TouchableOpacity
+                accessibilityRole="button"
+                accessibilityLabel="Close"
+                accessibilityHint="Dismiss banner"
                 testID="banner-close-button"
                 onPress={handleClose}
                 hitSlop={DEFAULT_HIT_SLOP}

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -147,6 +147,11 @@ export const Button: React.FC<ButtonProps> = ({
     <Spring native to={to} config={config.stiff}>
       {(springProps: typeof to) => (
         <Pressable
+          accessibilityLabel={rest.accessibilityLabel}
+          accessibilityRole="button"
+          accessibilityState={{
+            disabled,
+          }}
           hitSlop={hitSlop}
           testOnly_pressed={testOnly_state === DisplayState.Pressed}
           disabled={testOnly_state === DisplayState.Disabled || disabled}

--- a/src/elements/Button/LinkButton.tsx
+++ b/src/elements/Button/LinkButton.tsx
@@ -2,7 +2,7 @@ import { TextProps, Text } from "../Text"
 import { Touchable } from "../Touchable"
 
 export const LinkButton = (props: TextProps) => (
-  <Touchable onPress={props.onPress}>
+  <Touchable accessibilityRole="link" onPress={props.onPress}>
     <Text underline {...props} />
   </Touchable>
 )

--- a/src/elements/ButtonNew/Button.tsx
+++ b/src/elements/ButtonNew/Button.tsx
@@ -174,6 +174,11 @@ export const Button = ({
 
   return (
     <Pressable
+      accessibilityLabel={restProps.accessibilityLabel}
+      accessibilityRole="button"
+      accessibilityState={{
+        disabled,
+      }}
       disabled={disabled}
       onPressIn={() => {
         if (loading) {

--- a/src/elements/ButtonNew/LinkButton.tsx
+++ b/src/elements/ButtonNew/LinkButton.tsx
@@ -2,7 +2,7 @@ import { Text, TextProps } from "../Text"
 import { Touchable } from "../Touchable"
 
 export const LinkButton = (props: TextProps) => (
-  <Touchable onPress={props.onPress}>
+  <Touchable accessibilityRole="link" onPress={props.onPress}>
     <Text underline {...props} />
   </Touchable>
 )

--- a/src/elements/Checkbox/Checkbox.tsx
+++ b/src/elements/Checkbox/Checkbox.tsx
@@ -83,8 +83,11 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   const textColor = error ? color("red100") : disabled ? color("mono30") : color("mono100")
   const subtitleColor = error ? color("red100") : disabled ? color("mono30") : color("mono60")
 
+  // TODO: migrate away from using this checkbox implementation and
+  // use the one from the community solutions - reasoning - this is an inaccessible component
   return (
     <TouchableWithoutFeedback
+      accessibilityRole="checkbox"
       onPress={(event) => {
         if (disabled) {
           return

--- a/src/elements/Chip/Chip.tsx
+++ b/src/elements/Chip/Chip.tsx
@@ -32,6 +32,8 @@ export const Chip: FC<ChipProps> = ({ image, title, subtitle, onPress }) => {
 
   return (
     <Touchable
+      accessibilityRole="button"
+      accessibilityLabel={title}
       onPress={onPress}
       onPressIn={handleOnPressIn}
       onPressOut={handleOnPressOut}

--- a/src/elements/CollapsibleMenuItem/CollapsibleMenuItem.tsx
+++ b/src/elements/CollapsibleMenuItem/CollapsibleMenuItem.tsx
@@ -70,6 +70,10 @@ export const CollapsibleMenuItem = forwardRef<
     return (
       <Flex ref={componentRef} collapsable={false}>
         <Touchable
+          accessibilityRole="button"
+          accessibilityLabel="Collapsible Element"
+          accessibilityState={{ disabled }}
+          accessibilityHint={"Tap to " + (isOpen ? "collapse" : "expand")}
           onPress={() => {
             setIsOpen(!isOpen)
             isOpen ? onCollapse?.() : onExpand?.()

--- a/src/elements/Dialog/Dialog.tsx
+++ b/src/elements/Dialog/Dialog.tsx
@@ -69,7 +69,13 @@ export const Dialog = (props: DialogProps) => {
   return (
     <Modal {...other} visible={visible} statusBarTranslucent transparent animationType="none">
       {!!onBackgroundPress ? (
-        <TouchableWithoutFeedback testID="dialog-backdrop" onPress={onBackgroundPress}>
+        <TouchableWithoutFeedback
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss"
+          accessibilityHint="Dismisses the dialog"
+          testID="dialog-backdrop"
+          onPress={onBackgroundPress}
+        >
           {backdrop}
         </TouchableWithoutFeedback>
       ) : (

--- a/src/elements/Input/Input.tests.tsx
+++ b/src/elements/Input/Input.tests.tsx
@@ -36,9 +36,9 @@ describe("Input", () => {
 
     fireEvent(screen.getByTestId(testID), "onChangeText", "Banksy")
 
-    await screen.findByLabelText("Clear input button")
+    await screen.findByLabelText("Clear")
 
-    fireEvent.press(screen.getByLabelText("Clear input button"))
+    fireEvent.press(screen.getByLabelText("Clear"))
 
     expect(screen.queryByDisplayValue("Banksy")).toBeFalsy()
   })
@@ -48,19 +48,19 @@ describe("Input", () => {
 
     screen.getByPlaceholderText("password")
 
-    screen.getByLabelText("show password button")
+    screen.getByLabelText("show password icon")
 
     fireEvent(screen.getByPlaceholderText("password"), "onChangeText", "123456")
 
-    fireEvent.press(screen.getByLabelText("show password button"))
+    fireEvent.press(screen.getByLabelText("show password icon"))
 
-    expect(screen.queryByLabelText("show password button")).toBeFalsy()
-    screen.getByLabelText("hide password button")
+    expect(screen.queryByLabelText("show password icon")).toBeFalsy()
+    screen.getByLabelText("hide password icon")
 
-    fireEvent.press(screen.getByLabelText("hide password button"))
+    fireEvent.press(screen.getByLabelText("hide password icon"))
 
-    expect(screen.queryByLabelText("hide password button")).toBeFalsy()
-    screen.getByLabelText("show password button")
+    expect(screen.queryByLabelText("hide password icon")).toBeFalsy()
+    screen.getByLabelText("show password icon")
   })
 
   it("enables scrolling when multiline is true", () => {

--- a/src/elements/Input/Input.tests.tsx
+++ b/src/elements/Input/Input.tests.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { Input } from "./Input"
 import { renderWithWrappers } from "../../utils/tests/renderWithWrappers"
 

--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -401,6 +401,7 @@ export const Input = forwardRef<InputRef, InputProps>(
       if (onSelectTap) {
         return (
           <TouchableOpacity
+            accessibilityRole="button"
             onPress={onSelectTap}
             style={[
               leftComponentSharedStyles,
@@ -497,7 +498,9 @@ export const Input = forwardRef<InputRef, InputProps>(
               haptic="impactMedium"
               onPress={handleClear}
               hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
-              accessibilityLabel="Clear input button"
+              accessibilityRole="button"
+              accessibilityHint="Clears the input"
+              accessibilityLabel="Clear"
               testID="clear-input-button"
             >
               <XCircleIcon fill="mono30" />
@@ -526,7 +529,9 @@ export const Input = forwardRef<InputRef, InputProps>(
                 })
                 setShowPassword(!showPassword)
               }}
-              accessibilityLabel={showPassword ? "hide password button" : "show password button"}
+              accessibilityRole="button"
+              accessibilityLabel={showPassword ? "hide password icon" : "show password icon"}
+              accessibilityHint={showPassword ? "Hides the password" : "Shows the password"}
               hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
             >
               {!showPassword ? <EyeClosedIcon fill="mono30" /> : <EyeOpenedIcon fill="mono60" />}
@@ -591,6 +596,8 @@ export const Input = forwardRef<InputRef, InputProps>(
           }}
         >
           <Touchable
+            accessibilityRole="button"
+            accessibilityHint="hint"
             onPress={props.onHintPress}
             haptic="impactLight"
             hitSlop={{
@@ -656,7 +663,11 @@ export const Input = forwardRef<InputRef, InputProps>(
 
       return (
         <Flex flexDirection="row" zIndex={100} pointerEvents="none" height={LABEL_HEIGHT}>
-          <AnimatedText style={[labelStyles, labelAnimatedStyles]} numberOfLines={1}>
+          <AnimatedText
+            style={[labelStyles, labelAnimatedStyles]}
+            numberOfLines={1}
+            accessibilityLabel="input label"
+          >
             {" "}
             {props.title}{" "}
           </AnimatedText>

--- a/src/elements/LegacyScreen/LegacyScreen.tsx
+++ b/src/elements/LegacyScreen/LegacyScreen.tsx
@@ -113,7 +113,7 @@ export const Header: React.FC<HeaderProps> = ({ onBack, title, onSkip }) => {
       </Flex>
       {!!title && <Text>{title}</Text>}
       {!!onSkip && (
-        <Touchable haptic="impactLight" onPress={onSkip}>
+        <Touchable accessibilityRole="button" haptic="impactLight" onPress={onSkip}>
           <Flex height="100%" justifyContent="center">
             <Text textAlign="right" variant="xs">
               Skip

--- a/src/elements/LegacyTabs/StepTabs.tsx
+++ b/src/elements/LegacyTabs/StepTabs.tsx
@@ -23,7 +23,11 @@ export const StepTabs: React.FC<TabsProps> = ({ onTabPress, activeTab, tabs }) =
     <TabBarContainer scrollEnabled={false} activeTabIndex={activeTab} tabLayouts={tabLayouts}>
       {tabs.map(({ label, completed }, index) => {
         return (
-          <TouchableOpacity onPress={() => onTabSelect(label, index)} key={label + index}>
+          <TouchableOpacity
+            accessibilityRole="button"
+            onPress={() => onTabSelect(label, index)}
+            key={label + index}
+          >
             <Box
               width={tabWidth}
               justifyContent="space-between"

--- a/src/elements/LegacyTabs/Tab.tsx
+++ b/src/elements/LegacyTabs/Tab.tsx
@@ -14,7 +14,7 @@ export interface TabV3Props {
 export const TabV3 = ({ label, superscript, active, onLayout, onPress, style }: TabV3Props) => {
   const color = useColor()
   return (
-    <Pressable onPress={onPress}>
+    <Pressable accessibilityRole="button" onPress={onPress}>
       {({ pressed }) => (
         <View
           onLayout={onLayout}

--- a/src/elements/MenuItem/MenuItem.tsx
+++ b/src/elements/MenuItem/MenuItem.tsx
@@ -24,7 +24,14 @@ export const MenuItem = ({
 }: MenuItemProps) => {
   const color = useColor()
   return (
-    <Touchable onPress={onPress} underlayColor={color("mono5")} disabled={disabled}>
+    <Touchable
+      accessibilityRole="button"
+      accessibilityState={{ disabled }}
+      accessibilityLabel="Menu item ${title}"
+      onPress={onPress}
+      underlayColor={color("mono5")}
+      disabled={disabled}
+    >
       <Flex
         flexDirection="row"
         alignItems="center"

--- a/src/elements/Message/Message.tsx
+++ b/src/elements/Message/Message.tsx
@@ -106,6 +106,8 @@ export const Message: React.FC<MessageProps> = ({
           {!!showCloseButton && (
             <Flex style={{ marginTop: 2 }}>
               <TouchableOpacity
+                accessibilityRole="button"
+                accessibilityHint="Dismiss message"
                 testID="Message-close-button"
                 onPress={handleClose}
                 hitSlop={{ bottom: 10, right: 10, left: 10, top: 10 }}

--- a/src/elements/Radio/RadioButton.tsx
+++ b/src/elements/Radio/RadioButton.tsx
@@ -105,6 +105,7 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 
   return (
     <TouchableWithoutFeedback
+      accessibilityRole="radio"
       accessibilityState={accessibilityState}
       onPress={(event) => {
         if (disabled) {

--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -140,7 +140,14 @@ const Left: React.FC<{
   return (
     <>
       {leftElements || (
-        <Touchable onPress={onBack} underlayColor="transparent" hitSlop={DEFAULT_HIT_SLOP}>
+        <Touchable
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          accessibilityHint="Navigates to the previous screen"
+          onPress={onBack}
+          underlayColor="transparent"
+          hitSlop={DEFAULT_HIT_SLOP}
+        >
           <ArrowLeftIcon fill="onBackgroundHigh" />
         </Touchable>
       )}

--- a/src/elements/SearchInput/RoundSearchInput.tsx
+++ b/src/elements/SearchInput/RoundSearchInput.tsx
@@ -165,6 +165,8 @@ export const RoundSearchInput: React.FC<RoundSearchInputProps> = ({
         }}
       >
         <Touchable
+          accessibilityRole="button"
+          accessibilityLabel={`${isFocused ? "Back" : "Search"}`}
           onPress={() => {
             ref.current?.blur()
             setIsFocused(false)

--- a/src/elements/ToolTip/ToolTipFlyout.tsx
+++ b/src/elements/ToolTip/ToolTipFlyout.tsx
@@ -67,7 +67,12 @@ export const ToolTipFlyout: React.FC<Props> = ({
   }
 
   return (
-    <TouchableWithoutFeedback onPress={onPress} testID={testID}>
+    <TouchableWithoutFeedback
+      accessibilityLabel="Tooltip"
+      accessibilityHint="Tap to dismiss"
+      onPress={onPress}
+      testID={testID}
+    >
       <Animated.View
         style={[
           {

--- a/src/elements/Touchable/Touchable.stories.tsx
+++ b/src/elements/Touchable/Touchable.stories.tsx
@@ -11,10 +11,10 @@ export default {
 
 export const Examples = () => (
   <List>
-    <Touchable>
+    <Touchable accessibilityRole="button">
       <Text>This is a text wrapped in a `Touchable`.</Text>
     </Touchable>
-    <Touchable>
+    <Touchable accessibilityRole="button">
       <Flex width={200} alignItems="center" borderColor="red" borderWidth={1}>
         <TrashIcon />
         <Text>This is a cell with an icon and a text, wrapped in a `Touchable`.</Text>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2398,6 +2398,13 @@
     pirates "^4.0.5"
     source-map-support "^0.5.16"
 
+"@babel/runtime@^7.15.4":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.0.tgz#fbee7cf97c709518ecc1f590984481d5460d4762"
+  integrity sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/runtime@^7.17.9", "@babel/runtime@^7.7.6":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
@@ -5262,6 +5269,11 @@ asap@~2.0.6:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
+ast-types-flow@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==
+
 ast-types@0.15.2:
   version "0.15.2"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.15.2.tgz#39ae4809393c4b16df751ee563411423e85fb49d"
@@ -7020,6 +7032,15 @@ eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
+
+eslint-plugin-react-native-a11y@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-a11y/-/eslint-plugin-react-native-a11y-3.5.1.tgz#370339a308cace74409bfe582e9cfe627921f38a"
+  integrity sha512-vqnXZpAiov0lxYNfEYgwABpkiBYRrt0dbtOafPkw6QaFeA0uZ+s3w9opeEMoFmV36WFxLiCxHb9fvOJ+EUc2xQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    ast-types-flow "^0.0.7"
+    jsx-ast-utils "^3.2.1"
 
 eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"
@@ -9322,6 +9343,16 @@ jsonify@^0.0.1:
   dependencies:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
+
+jsx-ast-utils@^3.2.1:
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz#4766bd05a8e2a11af222becd19e15575e52a853a"
+  integrity sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==
+  dependencies:
+    array-includes "^3.1.6"
+    array.prototype.flat "^1.3.1"
+    object.assign "^4.1.4"
+    object.values "^1.1.6"
 
 kind-of@^6.0.2:
   version "6.0.3"


### PR DESCRIPTION
This PR resolves [PHIRE-1774] <!-- eg [PROJECT-XXXX] -->

### Description

Introduces `plugin:react-native-a11y/basic` for linting when it comes to basic accessibility.

Mostly adds Roles and Labels here and there on Touchables.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[PHIRE-1774]: https://artsyproduct.atlassian.net/browse/PHIRE-1774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ