### PR TITLE
feat: add selected a11y state to radioButton

### DIFF
--- a/src/elements/Radio/RadioButton.tsx
+++ b/src/elements/Radio/RadioButton.tsx
@@ -20,7 +20,7 @@ const DURATION = 150
 export interface RadioButtonProps
   extends Omit<TouchableWithoutFeedbackProps, "hitSlop">,
     Omit<FlexProps, "hitSlop"> {
-  accessibilityState?: { checked: boolean }
+  accessibilityState?: { checked?: boolean; selected?: boolean }
   accessibilityLabel?: string
   block?: boolean
   disabled?: boolean


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Adds selected a11y state to radioButton to be used when testing with `@testing-library/react-native` and to improve the a11y of the radiobutton

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
