### PR TITLE
fix: dark mode issues on Chip

### DIFF
--- a/src/elements/Chip/Chip.tsx
+++ b/src/elements/Chip/Chip.tsx
@@ -1,5 +1,5 @@
-import { useAnimationState, View } from "moti"
-import { FC } from "react"
+import { View } from "moti"
+import { FC, useState } from "react"
 import { useColor, useSpace } from "../../utils/hooks"
 import { Flex } from "../Flex"
 import { Image } from "../Image"
@@ -17,17 +17,17 @@ export const Chip: FC<ChipProps> = ({ image, title, subtitle, onPress }) => {
   const color = useColor()
   const space = useSpace()
 
-  const animatedState = useAnimationState({
-    from: { backgroundColor: color("mono10") },
-    to: { backgroundColor: color("mono5") },
-  })
+  const [isPressed, setIsPressed] = useState(false)
+
+  const FROM_COLOR = color("mono10")
+  const TO_COLOR = color("mono5")
 
   const handleOnPressIn = () => {
-    animatedState.transitionTo("from")
+    setIsPressed(true)
   }
 
   const handleOnPressOut = () => {
-    animatedState.transitionTo("to")
+    setIsPressed(false)
   }
 
   return (
@@ -43,7 +43,9 @@ export const Chip: FC<ChipProps> = ({ image, title, subtitle, onPress }) => {
         {!!image && <Image src={image} width={70} height={70} />}
 
         <View
-          state={animatedState}
+          animate={{
+            backgroundColor: !isPressed ? TO_COLOR : FROM_COLOR,
+          }}
           style={{
             flex: 1,
             padding: space(1),


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes an issue with the Chip component breaking when switching from light to dark mode. This was happening because we were using the static configuration, but since we released dark mode, It's not valid anymore.

<img width="500" alt="Screenshot 2025-06-04 at 11 20 59" src="https://github.com/user-attachments/assets/20ae872f-7d1f-4a2d-ba51-62fbe53eff0f" />

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/e1501d3e-e233-4281-9469-131400a6d5c8" /> | <video src="https://github.com/user-attachments/assets/7144616d-9138-41f8-9bb1-14f4a93ad82d" /> | 



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
