### PR TITLE
refactor(Input): update InputProps to improve type safety and clarity

### DIFF
--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -55,11 +55,6 @@ export interface InputProps extends Omit<TextInputProps, "placeholder" | "onChan
    * These lead to some issues when the parent component wants further control of the value
    */
   disabled?: boolean
-  /**
-   * Enables the clear button
-   * @warning This prop only works if `value` is specified
-   */
-  enableClearButton?: boolean
   error?: string
   fixedRightPlaceholder?: string
   hintText?: string
@@ -117,6 +112,26 @@ export interface InputProps extends Omit<TextInputProps, "placeholder" | "onChan
   value?: string | undefined
 }
 
+type InputPropsWithSecureText = InputProps & {
+  secureTextEntry: true
+  enableClearButton?: never
+}
+
+type InputPropsWithClearButton = InputProps & {
+  enableClearButton: true
+  secureTextEntry?: never
+}
+
+type InputPropsWithNeither = InputProps & {
+  enableClearButton?: boolean
+  secureTextEntry?: boolean
+}
+
+export type InputComponentProps =
+  | InputPropsWithSecureText
+  | InputPropsWithClearButton
+  | InputPropsWithNeither
+
 export const HORIZONTAL_PADDING = 15
 export const INPUT_BORDER_RADIUS = 4
 export const INPUT_MIN_HEIGHT = 56
@@ -132,7 +147,7 @@ export interface InputRef {
   clear: () => void
 }
 
-export const Input = forwardRef<InputRef, InputProps>(
+export const Input = forwardRef<InputRef, InputComponentProps>(
   (
     {
       addClearListener = false,

--- a/src/elements/SearchInput/SearchInput.tsx
+++ b/src/elements/SearchInput/SearchInput.tsx
@@ -1,7 +1,7 @@
 import { MagnifyingGlassIcon } from "../../svgs"
 import { useColor } from "../../utils/hooks"
 import { Flex } from "../Flex"
-import { Input, InputProps } from "../Input"
+import { Input, type InputProps } from "../Input"
 
 export interface SearchInputProps extends InputProps {
   enableCancelButton?: boolean


### PR DESCRIPTION
This PR resolves [PHIRE-1862] <!-- eg [PROJECT-XXXX] -->

### Description

Follow up to PHIRE-1862. 

#### 🎯 Problem

The Input component allowed both `secureTextEntry` and `enableClearButton` props to be used simultaneously, which creates a poor UX where both a password toggle and clear button would appear together.

#### 🛠️ Solution
Implemented a TypeScript discriminated union pattern to enforce mutual exclusivity between these props at compile time.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
