### PR TITLE
chore: export image skeleton

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1297,8 +1297,27 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-blurhash (1.1.11):
+  - react-native-blurhash (2.1.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.10.14.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-pager-view (6.5.0):
     - DoubleConversion
     - glog
@@ -2147,7 +2166,7 @@ SPEC CHECKSUMS:
   React-logger: dbca7bdfd4aa5ef69431362bde6b36d49403cb20
   React-Mapbuffer: 6efad4a606c1fae7e4a93385ee096681ef0300dc
   React-microtasksnativemodule: a645237a841d733861c70b69908ab4a1707b52ad
-  react-native-blurhash: a59e6bf8117a0304488ed576abd440f4b0777a8c
+  react-native-blurhash: f29e538969868d35ffa46091eafea5ee5396e56a
   react-native-pager-view: c6ea843be238c299d5553320dca295c101d556c9
   react-native-safe-area-context: 56f6a226ce946d7bd1cc232aea54d23cb1a852a1
   React-nativeconfig: 8efdb1ef1e9158c77098a93085438f7e7b463678

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.21",
     "moti": "^0.25.3",
     "react-nanny": "^2.15.0",
-    "react-native-blurhash": "^1.1.11",
+    "react-native-blurhash": "^2.1.1",
     "react-native-collapsible-tab-view": "^8.0.0",
     "react-native-fast-image": "^8.6.3",
     "react-native-pager-view": "6.5.0",

--- a/src/elements/Image/Image.tsx
+++ b/src/elements/Image/Image.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback } from "react"
-import { PixelRatio, View } from "react-native"
+import { PixelRatio, StyleProp, View, ViewStyle } from "react-native"
 import { Blurhash } from "react-native-blurhash"
 import FastImage, { FastImageProps } from "react-native-fast-image"
 import Animated, {
@@ -68,7 +68,13 @@ export const Image: React.FC<ImageProps> = memo(
     }, [])
 
     if (showLoadingState) {
-      return <ImageSkeleton dimensions={dimensions} blurhash={blurhash} />
+      return (
+        <ImageSkeleton
+          dimensions={dimensions}
+          blurhash={blurhash}
+          style={{ position: "absolute" }}
+        />
+      )
     }
 
     let uri = src
@@ -84,7 +90,11 @@ export const Image: React.FC<ImageProps> = memo(
     return (
       <Flex position="relative" {...flexProps} style={{ ...dimensions }}>
         <View style={[dimensions, { position: "absolute" }]}>
-          <ImageSkeleton dimensions={dimensions} blurhash={blurhash} />
+          <ImageSkeleton
+            dimensions={dimensions}
+            blurhash={blurhash}
+            style={{ position: "absolute" }}
+          />
         </View>
 
         <Animated.View style={animatedStyles}>
@@ -138,19 +148,20 @@ const useImageDimensions = (props: Pick<ImageProps, "aspectRatio" | "width" | "h
 type ImageSkeletonProps = {
   dimensions: { width: number; height: number }
   blurhash?: string | null | undefined
+  style?: StyleProp<ViewStyle>
 }
 
-const ImageSkeleton: React.FC<ImageSkeletonProps> = ({ dimensions, blurhash }) => {
+export const ImageSkeleton: React.FC<ImageSkeletonProps> = ({ dimensions, blurhash, style }) => {
   if (!!blurhash) {
     return (
-      <Flex position="absolute" backgroundColor="mono10" {...dimensions}>
+      <Flex backgroundColor="mono10" {...dimensions} style={style}>
         <Blurhash blurhash={blurhash} style={{ flex: 1 }} decodeWidth={16} decodeHeight={16} />
       </Flex>
     )
   }
 
   return (
-    <Flex position="absolute">
+    <Flex style={style}>
       <Skeleton>
         <SkeletonBox {...dimensions} />
       </Skeleton>

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -3,4 +3,11 @@ import "@testing-library/react-native/extend-expect"
 import mockSafeAreaContext from "react-native-safe-area-context/jest/mock"
 jest.mock("react-native-safe-area-context", () => mockSafeAreaContext)
 
+jest.mock("react-native-blurhash", () => {
+  const ReactNative = require("react-native")
+  return {
+    Blurhash: ReactNative.View as any,
+  }
+})
+
 require("react-native-reanimated").setUpTests()

--- a/yarn.lock
+++ b/yarn.lock
@@ -10921,10 +10921,10 @@ react-nanny@^2.15.0:
   resolved "https://registry.yarnpkg.com/react-nanny/-/react-nanny-2.15.0.tgz#9472984af45761263b92b209f925e773fd761653"
   integrity sha512-fn6tAnJ+UEdD0pq5YytlZJb5XmjVcvXoxq3i2r1o/BavgipwRWsw7oOXNJ8bJd33iedlkNyAQMXVC6qTl0Hv4A==
 
-react-native-blurhash@^1.1.11:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/react-native-blurhash/-/react-native-blurhash-1.1.11.tgz#cef102cc0239eb30c184235caf3fcb0b1f3ce33d"
-  integrity sha512-lYFf0C6vBz+wr5p81ABlzT9vSWmg4qTrtYGObBzhPOFIM8T0BHXbz0cCIE/gWgKFohLEWrwXFQ78GgHLlw7Jig==
+react-native-blurhash@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-blurhash/-/react-native-blurhash-2.1.1.tgz#c8079881422664691b387e43b020b846dfd196e6"
+  integrity sha512-b1aA5Tn31pPbqmaWnhJv7zSuN6o9M1t4yHciPunfP89LDkH2dvDIynvkE00Hen4Vmt6SnyXViSYH34MyvTvRiA==
 
 react-native-collapsible-tab-view@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
### Description

This PR exports `ImageSkeleton` to be used for image loaders.


Related PR: https://github.com/artsy/eigen/pull/12230


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
