### PR TITLE
build(deps): fix blurhash peerDepencency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-blurhash": "^1.1.11",
+    "react-native-blurhash": "*",
     "react-native-haptic-feedback": "*",
     "react-native-linear-gradient": "*",
     "react-native-reanimated": "*",


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Try to fix the issue that started happening after [this PR ](https://github.com/artsy/palette-mobile/pull/356/files)that bumped blurhash in palette-mobile.

We might also need to add:

```
jest.mock("react-native-blurhash", () => {
  const ReactNative = require("react-native")
  return {
    Blurhash: ReactNative.View as any,
  }
})
``` 

in palette but will check it on the automated pr

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
