### PR TITLE
fix(AnimatedHeader): title not being displayed

### DIFF
--- a/src/elements/Screen/Header.tsx
+++ b/src/elements/Screen/Header.tsx
@@ -1,9 +1,12 @@
-import { MotiView } from "moti"
 import React from "react"
-import { Dimensions } from "react-native"
-import Animated, { Easing, FadeIn, FadeOut, useDerivedValue } from "react-native-reanimated"
+import Animated, {
+  Easing,
+  FadeIn,
+  FadeOut,
+  useAnimatedStyle,
+  useDerivedValue,
+} from "react-native-reanimated"
 import { useScreenScrollContext } from "./ScreenScrollContext"
-import { BOTTOM_TABS_HEIGHT, STICKY_BAR_HEIGHT } from "./StickySubHeader"
 import { NAVBAR_HEIGHT, ZINDEX } from "./constants"
 import { DEFAULT_HIT_SLOP } from "../../constants"
 import { ArrowLeftIcon } from "../../svgs/ArrowLeftIcon"
@@ -78,24 +81,22 @@ const Center: React.FC<{
   hideTitle: HeaderProps["hideTitle"]
   title: HeaderProps["title"]
 }> = ({ animated, hideTitle, title }) => {
-  const {
-    scrollYOffset = 0,
-    currentScrollYAnimated,
-    scrollViewDimensionsAnimated,
-  } = useScreenScrollContext()
-  const { height: screenHeight } = Dimensions.get("window")
-
-  const scrollViewContentHeight =
-    screenHeight - NAVBAR_HEIGHT - STICKY_BAR_HEIGHT - BOTTOM_TABS_HEIGHT
+  const { scrollYOffset = 0, currentScrollYAnimated } = useScreenScrollContext()
 
   // Show / hide the title to avoid rerenders, which retrigger the animation
   const display = useDerivedValue(() => {
-    // The user is scrolling on a screen that is too small to show the small header
-    if (scrollViewDimensionsAnimated?.value < scrollViewContentHeight) {
-      return "none"
-    }
     return currentScrollYAnimated.value < NAVBAR_HEIGHT + scrollYOffset ? "none" : "flex"
   }, [currentScrollYAnimated, scrollYOffset])
+
+  const opacity = useDerivedValue(() => {
+    return display.value === "flex" ? 1 : 0
+  })
+  const style = useAnimatedStyle(() => {
+    return {
+      display: display.value,
+      opacity: opacity.value,
+    }
+  })
 
   if (hideTitle) {
     return null
@@ -115,17 +116,9 @@ const Center: React.FC<{
     <Animated.View
       entering={FadeIn.duration(400).easing(Easing.out(Easing.exp))}
       exiting={FadeOut.duration(400).easing(Easing.out(Easing.exp))}
-      style={{
-        display: display.value,
-      }}
+      style={style}
     >
-      <MotiView
-        animate={{
-          opacity: display.value === "flex" ? 1 : 0,
-        }}
-      >
-        {titleTextElement}
-      </MotiView>
+      {titleTextElement}
     </Animated.View>
   )
 }

--- a/src/elements/Tabs/Tabs.stories.tsx
+++ b/src/elements/Tabs/Tabs.stories.tsx
@@ -2,7 +2,6 @@ import { storiesOf } from "@storybook/react-native"
 import { Tabs } from "./Tabs"
 import { Flex } from "../Flex"
 import { Screen } from "../Screen"
-import { Spacer } from "../Spacer"
 import { Text } from "../Text"
 
 storiesOf("Tabs", module)
@@ -37,7 +36,6 @@ storiesOf("Tabs", module)
   .add("Tabs with AnimatedHeader", () => (
     <Screen>
       <Screen.AnimatedHeader title="Title" />
-
       <Screen.Body fullwidth>
         <Tabs>
           <Tabs.Tab name="tab1" label="Tab 1">
@@ -78,8 +76,8 @@ storiesOf("Tabs", module)
       showLargeHeaderText={false}
       BelowTitleHeaderComponent={() => (
         <Flex pointerEvents="none" p={2}>
-          <Text>Artist</Text>
-          <Text>Description</Text>
+          <Text>Info</Text>
+          <Text>More Info</Text>
         </Flex>
       )}
     >

--- a/src/elements/Tabs/hooks/useListenForTabContentScroll.tsx
+++ b/src/elements/Tabs/hooks/useListenForTabContentScroll.tsx
@@ -1,13 +1,23 @@
 import { useEffect } from "react"
 import { useCurrentTabScrollY } from "react-native-collapsible-tab-view"
+import { useAnimatedReaction } from "react-native-reanimated"
 import { useScreenScrollContext } from "../../Screen/ScreenScrollContext"
 import { useAnimatedHeaderScrolling } from "../../Screen/hooks/useAnimatedHeaderScrolling"
 
 export const useListenForTabContentScroll = () => {
-  const { updateCurrentScrollY, scrollYOffset } = useScreenScrollContext()
-  const scrollY = useAnimatedHeaderScrolling(useCurrentTabScrollY(), scrollYOffset)
+  // TODO: move away from JS variables, use the animated values instead
+  const { updateCurrentScrollY, scrollYOffset, currentScrollYAnimated } = useScreenScrollContext()
+  const currentTabScrollY = useCurrentTabScrollY()
+  const scrollY = useAnimatedHeaderScrolling(currentTabScrollY, scrollYOffset)
 
   useEffect(() => {
     updateCurrentScrollY(scrollY)
   }, [scrollY, updateCurrentScrollY])
+
+  useAnimatedReaction(
+    () => currentTabScrollY.value,
+    (current) => {
+      currentScrollYAnimated?.set(current)
+    }
+  )
 }


### PR DESCRIPTION
This PR resolves [PBRW-957] <!-- eg [PROJECT-XXXX] -->

### Description

- Removes the `scrollViewContentHeight` that we checked and it wasn't being correctly calculated, so we decided to skip it since it was causing a bug
- Adds a side-effect with `useAnimatedReaction` to update the newly introduced `currentScrollYAnimated` from past PRs


https://github.com/user-attachments/assets/3c72f168-201d-4703-85f0-dd54869bf28a



Co-authored by @MounirDhahri 




[PBRW-957]: https://artsyproduct.atlassian.net/browse/PBRW-957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ