### PR TITLE
chore: upgrade react-native-popover-view to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-native-blurhash": "^2.1.1",
     "react-native-collapsible-tab-view": "^8.0.1",
     "react-native-pager-view": "6.5.0",
-    "react-native-popover-view": "^5.1.7",
+    "react-native-popover-view": "^6.1.0",
     "react-spring": "8.0.23",
     "styled-system": "^5.1.5"
   },

--- a/src/elements/Popover/Popover.tsx
+++ b/src/elements/Popover/Popover.tsx
@@ -1,13 +1,14 @@
 import { Color } from "@artsy/palette-tokens"
-import { Platform, StatusBar, ViewStyle } from "react-native"
+import { ViewStyle } from "react-native"
 import RNPopover from "react-native-popover-view"
+import { PopoverProps as RNPopoverProps } from "react-native-popover-view/dist/Types"
 import { Easing } from "react-native-reanimated"
 import { CloseIcon } from "../../svgs"
 import { useColor } from "../../utils/hooks"
 import { Flex } from "../Flex"
 import { Touchable } from "../Touchable"
 
-interface PopoverProps {
+interface PopoverProps extends Omit<RNPopoverProps, "placement"> {
   children?: React.ReactElement
   variant?: PopoverVariant
   title?: React.ReactElement
@@ -36,6 +37,7 @@ export const Popover = ({
   title,
   content,
   noCloseIcon,
+  ...rest
 }: PopoverProps) => {
   const color = useColor()
 
@@ -74,8 +76,6 @@ export const Popover = ({
       popoverStyle={[{ backgroundColor: style.backgroundColor }, style.shadow]}
       from={children}
       isVisible={visible}
-      // this is required to make sure that the popover is positioned correctly on android
-      verticalOffset={Platform.OS === "android" ? -(StatusBar.currentHeight ?? 0) : 0}
       onCloseComplete={onCloseComplete}
       onOpenComplete={onOpenComplete}
       onRequestClose={onPressOutside}
@@ -85,6 +85,7 @@ export const Popover = ({
         duration: 400,
         easing: Easing.out(Easing.exp),
       }}
+      {...rest}
     >
       <Flex backgroundColor={POPOVER_VARIANTS[variant].backgroundColor} p={1}>
         <Flex flexDirection="row" justifyContent="space-between" alignItems="center">

--- a/yarn.lock
+++ b/yarn.lock
@@ -10959,10 +10959,10 @@ react-native-pager-view@6.5.0:
   resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.5.0.tgz#e7ee9a95cbb5ecc721dc92050051aec85b9a7979"
   integrity sha512-Buqc5mjCgIem7aIQU/seMKqhQr98YvBqRNilnoBb8hNGhCaQTE2yvYDwUhOytowyOkjCstLv7Fap2jcLm/k3Bw==
 
-react-native-popover-view@^5.1.7:
-  version "5.1.7"
-  resolved "https://registry.yarnpkg.com/react-native-popover-view/-/react-native-popover-view-5.1.7.tgz#12f1df9b7c142ab8fa1a3ded2919a4164823be45"
-  integrity sha512-Xa+zKYp9x62UNezT8o9SnqQaBQEHdGwGHZnFnA2bsXLneVRvvlBopNwMNj+p7N65qnPf3mmzWj+57ThtM1qFuw==
+react-native-popover-view@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-popover-view/-/react-native-popover-view-6.1.0.tgz#1d0dd1573d95edfb611a0f712d1439d5deb374a9"
+  integrity sha512-j1CB+yPwTKlBvIJBNb1AwiHyF/r+W5+AJIbHk79GRa+0z6PVtW4C7NWJWPqUVkCMOcJtewl6Pr6f2dc/87cVyQ==
   dependencies:
     deprecated-react-native-prop-types "^2.3.0"
     prop-types "^15.8.1"


### PR DESCRIPTION
### Description

This PR upgrades react-native-popover-view to the latest version. This helps us fix two issues:
- Status bar and navigation bar translucency 
- Remove vertical offset fix introduced here https://github.com/artsy/palette-mobile/pull/153 (it's now working fine without it)

| Before | After |
|--------|--------|
| <img width="739" height="830" alt="Screenshot 2025-07-16 at 12 11 03" src="https://github.com/user-attachments/assets/c1059197-b3bb-43a5-9d92-99f21ade20ca" /> | <img width="737" height="836" alt="Screenshot 2025-07-16 at 12 32 49" src="https://github.com/user-attachments/assets/38412c61-1db9-44d9-94a7-725fb8078276" />
296b86b6" /> | 




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
