### PR TITLE
chore: add explicit child prop for react 19 #trivial

### DIFF
--- a/src/elements/Message/Message.tsx
+++ b/src/elements/Message/Message.tsx
@@ -22,7 +22,7 @@ export interface MessageProps {
   variant?: MessageVariant
 }
 
-export const Message: React.FC<MessageProps> = ({
+export const Message: React.FC<React.PropsWithChildren<MessageProps>> = ({
   bodyTextStyle,
   children,
   containerStyle,


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Makes explicit that this component has children to make compatible with react 19. 

```
src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailBuyerProtection.tsx:22:6 - error TS2322: Type '{ children: Element; variant: "default"; containerStyle: { px: 1; }; }' is not assignable to type 'IntrinsicAttributes & MessageProps'.
  Property 'children' does not exist on type 'IntrinsicAttributes & MessageProps'.

22     <Message variant="default" containerStyle={{ px: 1 }}>
        ~~~~~~~


Found 1 error in src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailBuyerProtection.tsx:22
```

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
