### PR TITLE
refactor(defaultProps): replace default props handling with ES6 def. values

### DIFF
--- a/src/elements/Separator/Separator.tsx
+++ b/src/elements/Separator/Separator.tsx
@@ -7,14 +7,12 @@ export interface SeparatorProps extends SpaceProps, WidthProps, BorderProps {}
 /**
  * A horizontal divider whose width and spacing can be adjusted
  */
-export const Separator = styled.View<SeparatorProps>`
+export const Separator = styled.View.attrs<SeparatorProps>((props) => ({
+  width: props.width ?? "100%",
+}))<SeparatorProps>`
   border: 1px solid ${themeGet("colors.onBackgroundLow")};
   border-bottom-width: 0;
   ${space};
   ${width};
   ${border};
 `
-
-Separator.defaultProps = {
-  width: "100%",
-}

--- a/src/elements/Spinner/Spinner.tsx
+++ b/src/elements/Spinner/Spinner.tsx
@@ -42,8 +42,8 @@ export const getSize = (props: SpinnerProps | BarProps) => {
       }
     default:
       return {
-        width: props.width,
-        height: props.height,
+        width: props.width ?? 25,
+        height: props.height ?? 6,
       }
   }
 }
@@ -111,8 +111,3 @@ const Bar = styled(Animated.View)<BarProps>`
     `
   }};
 `
-
-Bar.defaultProps = {
-  width: 25,
-  height: 6,
-}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR refactors the remaining defaultProps references that are deprecated and will stop working in future versions with ES6 def. values.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
