### PR TITLE
build(deps): bump auto orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@5.3.0
-  auto: artsy/auto@2.2.0
+  node: circleci/node@6.3.0
+  auto: artsy/auto@2.3.0
   macos: circleci/macos@2.5.4
 
 only_main: &only_main


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Bumps auto orb and node orb to try to bypass this error after my node bump https://app.circleci.com/pipelines/github/artsy/palette-mobile/1399/workflows/e7184b2f-9959-42aa-8d39-debb35f12dfc/jobs/4311
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>19.4.0--canary.385.4316.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/palette-mobile@19.4.0--canary.385.4316.0
  # or 
  yarn add @artsy/palette-mobile@19.4.0--canary.385.4316.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
