### PR TITLE
chore(Revert): "chore: upgrade reanimated to 3.19.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "react-native-device-info": "14.0.4",
     "react-native-haptic-feedback": "1.14.0",
     "react-native-linear-gradient": "2.6.2",
-    "react-native-reanimated": "3.19.1",
+    "react-native-reanimated": "3.16.7",
     "react-native-safe-area-context": "5.4.1",
     "react-native-svg": "15.10.1",
     "react-test-renderer": "18.3.1",

--- a/src/elements/Input/Input.tests.tsx
+++ b/src/elements/Input/Input.tests.tsx
@@ -14,9 +14,7 @@ describe("Input", () => {
   it("uses correct font family", () => {
     renderWithWrappers(<Input testID={testID} placeholder="input" />)
 
-    expect(screen.getByPlaceholderText("input").props.style["0"].fontFamily).toEqual(
-      "Unica77LL-Regular"
-    )
+    expect(screen.getByPlaceholderText("input")).toHaveStyle({ fontFamily: "Unica77LL-Regular" })
   })
 
   it("mutates given text as value", () => {

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -9,5 +9,3 @@ jest.mock("react-native-blurhash", () => {
 })
 
 require("react-native-reanimated").setUpTests()
-//
-jest.mock("react-native-reanimated", () => require("react-native-reanimated/mock"))

--- a/yarn.lock
+++ b/yarn.lock
@@ -121,7 +121,7 @@ __metadata:
     react-native-linear-gradient: "npm:2.6.2"
     react-native-pager-view: "npm:6.5.0"
     react-native-popover-view: "npm:^6.1.0"
-    react-native-reanimated: "npm:3.19.1"
+    react-native-reanimated: "npm:3.16.7"
     react-native-safe-area-context: "npm:5.4.1"
     react-native-svg: "npm:15.10.1"
     react-spring: "npm:8.0.23"
@@ -13140,16 +13140,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-is-edge-to-edge@npm:1.1.7":
-  version: 1.1.7
-  resolution: "react-native-is-edge-to-edge@npm:1.1.7"
-  peerDependencies:
-    react: "*"
-    react-native: "*"
-  checksum: 10c0/b7a37437f439b1e27a4d980de01994aa71b9091dc3ed00c21172d5505fb11978cd5ed3a43f97c89d502a3a08cf26e5cea6435b8d6e93d3557a92dd43563f7021
-  languageName: node
-  linkType: hard
-
 "react-native-linear-gradient@npm:2.6.2":
   version: 2.6.2
   resolution: "react-native-linear-gradient@npm:2.6.2"
@@ -13180,9 +13170,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:3.19.1":
-  version: 3.19.1
-  resolution: "react-native-reanimated@npm:3.19.1"
+"react-native-reanimated@npm:3.16.7":
+  version: 3.16.7
+  resolution: "react-native-reanimated@npm:3.16.7"
   dependencies:
     "@babel/plugin-transform-arrow-functions": "npm:^7.0.0-0"
     "@babel/plugin-transform-class-properties": "npm:^7.0.0-0"
@@ -13195,12 +13185,11 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.16.7"
     convert-source-map: "npm:^2.0.0"
     invariant: "npm:^2.2.4"
-    react-native-is-edge-to-edge: "npm:1.1.7"
   peerDependencies:
     "@babel/core": ^7.0.0-0
     react: "*"
     react-native: "*"
-  checksum: 10c0/82f83f8cd307dbb3d0d435a7c801fa27d06265b1eed51844013682e133072e447fd15c3f12814f4bd8d4759c89ad4b1043631611284afbd8e6eb505f57af0f12
+  checksum: 10c0/007cbec677d036e8d2c0744dfff52282ddfb9a89bb3eee82e7eaebcf731b07505e241af04ac87a38da038a18e380b32ec8a55263d1bb8559274d1c077b0b1d25
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Reverts artsy/palette-mobile#390

the reason for this is that react native of palette-mobile is not compatible with this reanimated version (see compatibility [table here](https://docs.swmansion.com/react-native-reanimated/docs/guides/compatibility/)) 

