### PR TITLE
fix: large button cropped

### DIFF
--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -7,7 +7,7 @@ import { config } from "react-spring"
 import { animated, Spring } from "react-spring/renderprops-native"
 import styled from "styled-components/native"
 import { Color, SpacingUnit } from "../../types"
-import { useColor, useTheme } from "../../utils/hooks"
+import { useColor } from "../../utils/hooks"
 import { isTestEnvironment } from "../../utils/tests/isTestEnvironment"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex/Flex"
@@ -15,6 +15,7 @@ import { MeasuredView, ViewMeasurements } from "../MeasuredView"
 import { Spacer } from "../Spacer"
 import { Spinner } from "../Spinner"
 import { Text } from "../Text/Text"
+import { useTextStyleForPalette } from "../Text/helpers"
 
 export interface ButtonProps extends BoxProps {
   children: React.ReactNode
@@ -85,9 +86,8 @@ export const Button: React.FC<ButtonProps> = ({
   hitSlop,
   ...rest
 }) => {
-  const { theme } = useTheme()
   const textVariantBySize = size === "small" ? "xs" : "sm"
-  const { fontSize } = theme.textTreatments[textVariantBySize]
+  const textStyle = { fontSize: useTextStyleForPalette(textVariant ?? textVariantBySize).fontSize }
 
   const [innerDisplayState, setInnerDisplayState] = useState(DisplayState.Enabled)
 
@@ -200,18 +200,20 @@ export const Button: React.FC<ButtonProps> = ({
                   */}
                   {!isTestEnvironment() && longestText && (
                     <MeasuredView setMeasuredState={setLongestTextMeasurements}>
-                      <Text color="red" style={{ fontSize }}>
+                      <Text color="red" style={textStyle}>
                         {longestText ? longestText : children}
                       </Text>
                     </MeasuredView>
                   )}
                   <AnimatedText
-                    style={{
-                      fontSize,
-                      width: longestText ? Math.ceil(longestTextMeasurements.width) : "auto",
-                      color: springProps.textColor,
-                      textDecorationLine: springProps.textDecorationLine,
-                    }}
+                    style={[
+                      {
+                        width: longestText ? Math.ceil(longestTextMeasurements.width) : "auto",
+                        color: springProps.textColor,
+                        textDecorationLine: springProps.textDecorationLine,
+                      },
+                      textStyle,
+                    ]}
                     textAlign="center"
                   >
                     {children}

--- a/src/elements/Button/Button.tsx
+++ b/src/elements/Button/Button.tsx
@@ -1,13 +1,13 @@
 import { TextVariant } from "@artsy/palette-tokens/dist/typography/v3" // TODO: remove palette-tokens when this file (Button.tsx) is removed.
 import { useState } from "react"
-import { PressableProps, TextStyle, GestureResponderEvent, Pressable } from "react-native"
+import { GestureResponderEvent, Pressable, PressableProps, TextStyle } from "react-native"
 import Haptic, { HapticFeedbackTypes } from "react-native-haptic-feedback"
 import { config } from "react-spring"
 // @ts-ignore
 import { animated, Spring } from "react-spring/renderprops-native"
 import styled from "styled-components/native"
 import { Color, SpacingUnit } from "../../types"
-import { useColor } from "../../utils/hooks"
+import { useColor, useTheme } from "../../utils/hooks"
 import { isTestEnvironment } from "../../utils/tests/isTestEnvironment"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex/Flex"
@@ -15,7 +15,6 @@ import { MeasuredView, ViewMeasurements } from "../MeasuredView"
 import { Spacer } from "../Spacer"
 import { Spinner } from "../Spinner"
 import { Text } from "../Text/Text"
-import { useTextStyleForPalette } from "../Text/helpers"
 
 export interface ButtonProps extends BoxProps {
   children: React.ReactNode
@@ -86,8 +85,9 @@ export const Button: React.FC<ButtonProps> = ({
   hitSlop,
   ...rest
 }) => {
+  const { theme } = useTheme()
   const textVariantBySize = size === "small" ? "xs" : "sm"
-  const textStyle = useTextStyleForPalette(textVariant ?? textVariantBySize)
+  const { fontSize } = theme.textTreatments[textVariantBySize]
 
   const [innerDisplayState, setInnerDisplayState] = useState(DisplayState.Enabled)
 
@@ -200,20 +200,18 @@ export const Button: React.FC<ButtonProps> = ({
                   */}
                   {!isTestEnvironment() && longestText && (
                     <MeasuredView setMeasuredState={setLongestTextMeasurements}>
-                      <Text color="red" style={textStyle}>
+                      <Text color="red" style={{ fontSize }}>
                         {longestText ? longestText : children}
                       </Text>
                     </MeasuredView>
                   )}
                   <AnimatedText
-                    style={[
-                      {
-                        width: longestText ? Math.ceil(longestTextMeasurements.width) : "auto",
-                        color: springProps.textColor,
-                        textDecorationLine: springProps.textDecorationLine,
-                      },
-                      textStyle,
-                    ]}
+                    style={{
+                      fontSize,
+                      width: longestText ? Math.ceil(longestTextMeasurements.width) : "auto",
+                      color: springProps.textColor,
+                      textDecorationLine: springProps.textDecorationLine,
+                    }}
                     textAlign="center"
                   >
                     {children}

--- a/src/elements/ButtonNew/Button.tsx
+++ b/src/elements/ButtonNew/Button.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { PressableProps, GestureResponderEvent, Pressable } from "react-native"
+import { GestureResponderEvent, Pressable, PressableProps } from "react-native"
 import Haptic, { HapticFeedbackTypes } from "react-native-haptic-feedback"
 import Animated, {
   interpolateColor,
@@ -11,11 +11,12 @@ import Animated, {
 } from "react-native-reanimated"
 import { useColorsForVariantAndState } from "./colors"
 import { MeasuredView, ViewMeasurements } from "../../elements/MeasuredView"
+import { useTheme } from "../../utils/hooks"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex"
 import { Spacer } from "../Spacer"
 import { Spinner } from "../Spinner"
-import { Text, useTextStyleForPalette } from "../Text"
+import { Text } from "../Text"
 
 const ANIMATION_DURATION = 150
 
@@ -100,7 +101,10 @@ export const Button = ({
     }
   )
 
-  const textStyle = useTextStyleForPalette(size === "small" ? "xs" : "sm")
+  const { theme } = useTheme()
+  const textVariantBySize = size === "small" ? "xs" : "sm"
+  const { fontSize } = theme.textTreatments[textVariantBySize]
+
   const [longestTextMeasurements, setLongestTextMeasurements] = useState<ViewMeasurements>({
     width: 0,
     height: 0,
@@ -228,14 +232,14 @@ export const Button = ({
               ) : null}
 
               <AText
-                style={[{ width: Math.ceil(longestTextMeasurements.width) }, textStyle, textAnim]}
+                style={[{ width: Math.ceil(longestTextMeasurements.width), fontSize }, textAnim]}
                 textAlign="center"
               >
                 {children}
               </AText>
 
               <MeasuredView setMeasuredState={setLongestTextMeasurements}>
-                <Text color="red" style={textStyle}>
+                <Text color="red" style={{ fontSize }}>
                   {longestText ? longestText : children}
                 </Text>
               </MeasuredView>

--- a/src/elements/ButtonNew/Button.tsx
+++ b/src/elements/ButtonNew/Button.tsx
@@ -9,14 +9,13 @@ import Animated, {
   useSharedValue,
   withTiming,
 } from "react-native-reanimated"
-import { useColorsForVariantAndState } from "./colors"
 import { MeasuredView, ViewMeasurements } from "../../elements/MeasuredView"
-import { useTheme } from "../../utils/hooks"
 import { Box, BoxProps } from "../Box"
 import { Flex } from "../Flex"
 import { Spacer } from "../Spacer"
 import { Spinner } from "../Spinner"
-import { Text } from "../Text"
+import { Text, useTextStyleForPalette } from "../Text"
+import { useColorsForVariantAndState } from "./colors"
 
 const ANIMATION_DURATION = 150
 
@@ -101,9 +100,7 @@ export const Button = ({
     }
   )
 
-  const { theme } = useTheme()
-  const textVariantBySize = size === "small" ? "xs" : "sm"
-  const { fontSize } = theme.textTreatments[textVariantBySize]
+  const textStyle = { fontSize: useTextStyleForPalette(size === "small" ? "xs" : "sm").fontSize }
 
   const [longestTextMeasurements, setLongestTextMeasurements] = useState<ViewMeasurements>({
     width: 0,
@@ -232,14 +229,14 @@ export const Button = ({
               ) : null}
 
               <AText
-                style={[{ width: Math.ceil(longestTextMeasurements.width), fontSize }, textAnim]}
+                style={[{ width: Math.ceil(longestTextMeasurements.width) }, textStyle, textAnim]}
                 textAlign="center"
               >
                 {children}
               </AText>
 
               <MeasuredView setMeasuredState={setLongestTextMeasurements}>
-                <Text color="red" style={{ fontSize }}>
+                <Text color="red" style={textStyle}>
                   {longestText ? longestText : children}
                 </Text>
               </MeasuredView>

--- a/src/elements/Text/helpers.ts
+++ b/src/elements/Text/helpers.ts
@@ -27,3 +27,14 @@ export const useFontFamilyFor = ({
 
   return fonts.sans.regular
 }
+
+export const useTextStyleForPalette = (variant: NoUndefined<TextProps["variant"]>): TextStyle => {
+  const { theme } = useTheme()
+
+  const fontSizeAndLineHeight = theme.textTreatments[variant].fontSize
+
+  return {
+    fontSize: fontSizeAndLineHeight,
+    lineHeight: fontSizeAndLineHeight,
+  }
+}

--- a/src/elements/Text/helpers.ts
+++ b/src/elements/Text/helpers.ts
@@ -27,19 +27,3 @@ export const useFontFamilyFor = ({
 
   return fonts.sans.regular
 }
-
-/**
- * Use this function within Palette and other "atom" components like `Button`, `Pill`, etc.
- * This function returns a `TextStyle` that has a `fontSize` and `lineHeight` of the same number.
- * This is to make a `Text` behave correctly when it needs to be combined with others to make a UI component.
- * Don't use this function when some actual text needs to be displayed. Only use it when text needs to be part of a UI component.
- */
-export const useTextStyleForPalette = (variant: NoUndefined<TextProps["variant"]>): TextStyle => {
-  const { theme } = useTheme()
-
-  const textTreatment = theme.textTreatments[variant]
-
-  return {
-    fontSize: textTreatment.fontSize,
-  }
-}

--- a/src/elements/Text/helpers.ts
+++ b/src/elements/Text/helpers.ts
@@ -37,10 +37,9 @@ export const useFontFamilyFor = ({
 export const useTextStyleForPalette = (variant: NoUndefined<TextProps["variant"]>): TextStyle => {
   const { theme } = useTheme()
 
-  const fontSizeAndLineHeight = theme.textTreatments[variant].fontSize
+  const textTreatment = theme.textTreatments[variant]
 
   return {
-    fontSize: fontSizeAndLineHeight,
-    lineHeight: fontSizeAndLineHeight,
+    fontSize: textTreatment.fontSize,
   }
 }

--- a/src/elements/Text/helpers.ts
+++ b/src/elements/Text/helpers.ts
@@ -28,6 +28,12 @@ export const useFontFamilyFor = ({
   return fonts.sans.regular
 }
 
+/**
+ * Use this function within Palette and other "atom" components like `Button`, `Pill`, etc.
+ * This function returns a `TextStyle` that has a `fontSize` and `lineHeight` of the same number.
+ * This is to make a `Text` behave correctly when it needs to be combined with others to make a UI component.
+ * Don't use this function when some actual text needs to be displayed. Only use it when text needs to be part of a UI component.
+ */
 export const useTextStyleForPalette = (variant: NoUndefined<TextProps["variant"]>): TextStyle => {
   const { theme } = useTheme()
 


### PR DESCRIPTION
This PR resolves [PHIRE-2350]

### Description

This PR fixes the broken text insde Palette's button.

This was recently raised in Energy and finally I had time to look into it. 

This was broken in previous releases of react-native, and the fix used to be to add the text line height. However since a few releases, this is no longer required and it's working fine on both platforms.

| Platform | Before | After |
|--------|--------|--------|
| Android | <img width="1080" height="2424" alt="Screenshot_1759319119" src="https://github.com/user-attachments/assets/48bfa62c-29f6-44c3-8bc2-652f4473cab9" /> | <img width="1080" height="2424" alt="Screenshot_1759319406" src="https://github.com/user-attachments/assets/07309b02-3add-45e9-bbc6-1c0ffe392cc7" /> |
| iOS | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-01 at 14 30 12" src="https://github.com/user-attachments/assets/61b0d3db-1d5c-4d19-99a2-1e9cfbade3f7" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-01 at 14 30 04" src="https://github.com/user-attachments/assets/3de69e2b-7a8f-4b6b-b368-c3f09af8f14c" /> | 


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


[PHIRE-2350]: https://artsyproduct.atlassian.net/browse/PHIRE-2350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ