### PR TITLE
fix: remove jotai and refactor to use useState in order to fix palette-mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
   "files": [
     "dist"
   ],
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "jest-environment-jsdom": "29.4.2",
     "jest-extended": "3.2.3",
     "jest-watch-typeahead": "2.2.2",
-    "jotai": "^2.15.0",
     "lint-staged": "13.1.2",
     "nodemon": "^2.0.20",
     "patch-package": "^8.0.0",
@@ -144,7 +143,6 @@
   "files": [
     "dist"
   ],
-  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"

--- a/src/storybook/decorators.tsx
+++ b/src/storybook/decorators.tsx
@@ -1,7 +1,4 @@
-import AsyncStorage from "@react-native-async-storage/async-storage"
-import { useAtom } from "jotai"
-import { atomWithStorage, createJSONStorage } from "jotai/utils"
-import { ReactNode, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { Appearance } from "react-native"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 import { Theme } from "../Theme"
@@ -17,31 +14,16 @@ export const withTheme: Decorator = (story) => (
   </Theme>
 )
 
-const atomStorage = createJSONStorage<any>(() => AsyncStorage)
-const atomWithAsyncStorage = <T,>(key: string, initialValue: any) =>
-  atomWithStorage<T>(
-    key,
-    initialValue,
-    {
-      ...atomStorage,
-    },
-    {
-      getOnInit: false,
-    }
-  )
-
-const modeAtom = atomWithAsyncStorage<"light" | "dark" | "system">("dark-mode-mode", "system")
-
 export const useDarkModeSwitcher: Decorator = (story) => {
-  const [mode, setMode] = useAtom(modeAtom)
+  const [mode, setMode] = useState<"light" | "dark" | "system">("system")
   const [systemMode, setSystemMode] = useState<"light" | "dark">(
     Appearance.getColorScheme() ?? "light"
   )
 
   useEffect(() => {
-    const subscription = Appearance.addChangeListener(
-      ({ colorScheme }) => void setSystemMode(colorScheme ?? "light")
-    )
+    const subscription = Appearance.addChangeListener(({ colorScheme }) => {
+      setSystemMode(colorScheme ?? "light")
+    })
     return () => subscription.remove()
   }, [])
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,7 +101,6 @@ __metadata:
     jest-environment-jsdom: "npm:29.4.2"
     jest-extended: "npm:3.2.3"
     jest-watch-typeahead: "npm:2.2.2"
-    jotai: "npm:^2.15.0"
     lint-staged: "npm:13.1.2"
     lodash: "npm:^4.17.21"
     moti: "npm:^0.25.3"
@@ -10103,27 +10102,6 @@ __metadata:
   version: 0.16.1
   resolution: "jimp-compact@npm:0.16.1"
   checksum: 10c0/2d73bb927d840ce6dc093d089d770eddbb81472635ced7cad1d7c4545d8734aecf5bd3dedf7178a6cfab4d06c9d6cbbf59e5cb274ed99ca11cd4835a6374f16c
-  languageName: node
-  linkType: hard
-
-"jotai@npm:^2.15.0":
-  version: 2.15.0
-  resolution: "jotai@npm:2.15.0"
-  peerDependencies:
-    "@babel/core": ">=7.0.0"
-    "@babel/template": ">=7.0.0"
-    "@types/react": ">=17.0.0"
-    react: ">=17.0.0"
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
-    "@babel/template":
-      optional: true
-    "@types/react":
-      optional: true
-    react:
-      optional: true
-  checksum: 10c0/fbe67f504f293bf59bcd6855f5e603c6a51ad6d839eee46ef79e85a5b8a2cd8530a26f47cb65fa5afbc55d336fa2df5f832b264d32fd12fb0d53c68f9bf36687
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Realised that palette-mobile wasn't running locally after my [expo bump PR](https://github.com/artsy/palette-mobile/pull/392) and the error was looking something like this:

<img width="300" alt="Screenshot 2025-10-02 at 17 50 30" src="https://github.com/user-attachments/assets/50c2fd3c-73c2-49bb-90f2-be379d9cf955" />

Located the issue to be in jotai and I just refactored the storybook decorator to use useState instead of jotai and got rid of the dependency since we don't need another state manager :P 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
