### PR TITLE
chore: downgrade reanimated

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "react-native-gesture-handler": "~2.22.1",
     "react-native-haptic-feedback": "1.14.0",
     "react-native-linear-gradient": "2.6.2",
-    "react-native-reanimated": "3.17.5",
+    "react-native-reanimated": "3.18.0",
     "react-native-safe-area-context": "5.4.1",
     "react-native-svg": "15.12.0",
     "react-test-renderer": "19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,7 +122,7 @@ __metadata:
     react-native-linear-gradient: "npm:2.6.2"
     react-native-pager-view: "npm:6.7.1"
     react-native-popover-view: "npm:^6.1.0"
-    react-native-reanimated: "npm:3.17.5"
+    react-native-reanimated: "npm:3.18.0"
     react-native-safe-area-context: "npm:5.4.1"
     react-native-svg: "npm:15.12.0"
     react-spring: "npm:8.0.23"
@@ -12263,9 +12263,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:3.17.5":
-  version: 3.17.5
-  resolution: "react-native-reanimated@npm:3.17.5"
+"react-native-reanimated@npm:3.18.0":
+  version: 3.18.0
+  resolution: "react-native-reanimated@npm:3.18.0"
   dependencies:
     "@babel/plugin-transform-arrow-functions": "npm:^7.0.0-0"
     "@babel/plugin-transform-class-properties": "npm:^7.0.0-0"
@@ -12283,7 +12283,7 @@ __metadata:
     "@babel/core": ^7.0.0-0
     react: "*"
     react-native: "*"
-  checksum: 10c0/22788541546cf3e818f0ad9fc9fb1cb53fd7b398d5f49078cd6adf8064957663d97de4e60de9e7894a359d2379685a9dd5d69183c3e13b5e4e78f2d49333921a
+  checksum: 10c0/7420f410a76b2a46f1a0a7df41f8b2508aade8de26fd00eb7305bf25b3ab27e7c06f52ec76d221d8c7317ca3e2bdf842c51216f2adba7fbb60ce321c171d1437
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This PR comes as a follow-up to the last crash coming from reanimated 3.19.1

There is a fix already that isn't merged yet inside `react-native-reanimated` repo. The latter is pretty complex so I didn't feel comfortable with patching it.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
