### PR TITLE
build(deps): bump @d11/react-native-fast-image from 8.12.0 to 8.13.0

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@artsy/palette-mobile": "*",
-    "@d11/react-native-fast-image": "8.12.0",
+    "@d11/react-native-fast-image": "8.13.0",
     "@gorhom/bottom-sheet": "5.1.8",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.4.4",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
     concurrent-ruby (1.3.3)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     drb (2.2.3)
     escape (0.0.4)
     ethon (0.15.0)

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@babel/preset-react": "7.18.6",
     "@babel/preset-typescript": "7.18.6",
     "@babel/runtime": "^7.25.0",
-    "@d11/react-native-fast-image": "8.12.0",
+    "@d11/react-native-fast-image": "8.13.0",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native/eslint-config": "0.76.9",
     "@shopify/flash-list": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,7 +59,7 @@ __metadata:
     "@babel/preset-react": "npm:7.18.6"
     "@babel/preset-typescript": "npm:7.18.6"
     "@babel/runtime": "npm:^7.25.0"
-    "@d11/react-native-fast-image": "npm:8.12.0"
+    "@d11/react-native-fast-image": "npm:8.13.0"
     "@react-native-async-storage/async-storage": "npm:^2.2.0"
     "@react-native/eslint-config": "npm:0.76.9"
     "@react-spring/native": "npm:10.0.3"
@@ -2169,13 +2169,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@d11/react-native-fast-image@npm:8.12.0":
-  version: 8.12.0
-  resolution: "@d11/react-native-fast-image@npm:8.12.0"
+"@d11/react-native-fast-image@npm:8.13.0":
+  version: 8.13.0
+  resolution: "@d11/react-native-fast-image@npm:8.13.0"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 10c0/9f3139b0796fbbaf7be5f9292dac13997d7da9c00916b8b26c7648271e07c593ebe1613b70f88057f93468a3889f0de133af87e36b85a460b31376b0820fa716
+  checksum: 10c0/697d43bade639333aad905cff00c315d8a9e3fb1352cec7c70c5100edaae9f9e05da8ddbcdd032820dcb4d4082ebb6290e59b040d9f0f31a64855b34d2a9e66d
   languageName: node
   linkType: hard
 
@@ -12460,7 +12460,7 @@ __metadata:
   resolution: "palette-mobile-example@workspace:Example"
   dependencies:
     "@artsy/palette-mobile": "npm:*"
-    "@d11/react-native-fast-image": "npm:8.12.0"
+    "@d11/react-native-fast-image": "npm:8.13.0"
     "@gorhom/bottom-sheet": "npm:5.1.8"
     "@react-native-async-storage/async-storage": "npm:2.2.0"
     "@react-native-community/datetimepicker": "npm:8.4.4"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Bumps fast image to latest

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
