### PR TITLE
fix: runtime error + stories for placeholderarray

### DIFF
--- a/Example/.storybook/storybook.requires.js
+++ b/Example/.storybook/storybook.requires.js
@@ -2,6 +2,7 @@
 
 import { start, updateView } from "@storybook/react-native"
 
+import "@storybook/addon-ondevice-controls/register"
 import "@storybook/addon-ondevice-actions/register"
 
 const normalizedStories = [

--- a/src/elements/Input/Input.stories.tsx
+++ b/src/elements/Input/Input.stories.tsx
@@ -5,6 +5,19 @@ import { Join } from "../Join"
 import { Separator } from "../Separator"
 import { Text } from "../Text"
 
+const artworkSearchPlaceholders = [
+  "Search by artist, artwork title, gallery, fair, or collecting category",
+  "Search by artist, artwork title, gallery, or fair",
+  "Search by artist, artwork, or gallery",
+  "Search artworks",
+]
+
+const shippingAddressPlaceholders = [
+  "Street address, apartment or suite, delivery instructions",
+  "Street address and apartment or suite",
+  "Street address",
+]
+
 export default {
   title: "Input",
 }
@@ -68,9 +81,6 @@ export const Variants = () => (
       </>
 
       <>
-        <Input placeholder="I'm a placeholder" />
-      </>
-      <>
         <Text mb={1} variant="sm-display" fontWeight="bold">
           With title, clear button and value
         </Text>
@@ -84,9 +94,21 @@ export const Variants = () => (
       </>
       <>
         <Text mb={1} variant="sm-display" fontWeight="bold">
-          With placeholder
+          Placeholder (single string)
         </Text>
-        <Input placeholder="I'm a placeholder" />
+        <Input placeholder="Search artworks" />
+      </>
+      <>
+        <Text mb={1} variant="sm-display" fontWeight="bold">
+          Placeholder (array, longest to shortest)
+        </Text>
+        <Input placeholder={artworkSearchPlaceholders} />
+      </>
+      <>
+        <Text mb={1} variant="sm-display" fontWeight="bold">
+          Placeholder with title (array, adaptive)
+        </Text>
+        <Input title="Search" placeholder={artworkSearchPlaceholders} />
       </>
       <>
         <Text mb={1} variant="sm-display" fontWeight="bold">
@@ -117,9 +139,15 @@ export const Variants = () => (
       </>
       <>
         <Text mb={1} variant="sm-display" fontWeight="bold">
-          multine with placeholder
+          Multiline with placeholder (single string)
         </Text>
         <Input title="Text area" multiline placeholder="Enter your message" />
+      </>
+      <>
+        <Text mb={1} variant="sm-display" fontWeight="bold">
+          Multiline with placeholder (array, adaptive)
+        </Text>
+        <Input title="Shipping address" multiline placeholder={shippingAddressPlaceholders} />
       </>
     </Join>
   </List>

--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -723,7 +723,7 @@ export const Input = forwardRef<InputRef, InputComponentProps>(
         >
           {placeholder.map((placeholderString, index) => (
             <Text
-              key={index}
+              key={`${placeholderString.replaceAll(" ", "-")}-${index}`}
               onLayout={(event) => {
                 placeholderWidths.current[index] = event.nativeEvent.layout.width
               }}

--- a/src/elements/Input/Input.tsx
+++ b/src/elements/Input/Input.tsx
@@ -18,10 +18,8 @@ import {
 } from "react"
 import {
   LayoutAnimation,
-  NativeSyntheticEvent,
   Platform,
   TextInput,
-  TextInputFocusEventData,
   TextInputProps,
   TouchableOpacity,
   ViewProps,
@@ -381,12 +379,12 @@ export const Input = forwardRef<InputRef, InputComponentProps>(
       }
     })
 
-    const handleFocus = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
+    const handleFocus = (e: Parameters<NonNullable<TextInputProps["onFocus"]>>[0]) => {
       setIsFocused(true)
       onFocus?.(e)
     }
 
-    const handleBlur = (e: NativeSyntheticEvent<TextInputFocusEventData>) => {
+    const handleBlur = (e: Parameters<NonNullable<TextInputProps["onBlur"]>>[0]) => {
       setIsFocused(false)
       onBlur?.(e)
     }
@@ -725,6 +723,7 @@ export const Input = forwardRef<InputRef, InputComponentProps>(
         >
           {placeholder.map((placeholderString, index) => (
             <Text
+              key={index}
               onLayout={(event) => {
                 placeholderWidths.current[index] = event.nativeEvent.layout.width
               }}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

There was a runtime error in eigen on inputs that had array placeholder and this PR fixes it, see eigen video below for before and after.

Also adds a few stories for array placeholders that we didn't have before

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/f2c6610a-a502-4183-827c-1efa4048129c" width="400" />|<video src="https://github.com/user-attachments/assets/2684b90b-2e18-4117-a39a-3c30bade0e2d" width="400" />|





