### PR TITLE
build(deps): bump react-native-pager-view to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "react-native-collapsible-tab-view": "patch:react-native-collapsible-tab-view@npm%3A9.0.0-rc.0#~/.yarn/patches/react-native-collapsible-tab-view-npm-9.0.0-rc.0-5363b327de.patch",
     "react-native-haptic-feedback": "1.14.0",
     "react-native-linear-gradient": "2.8.3",
-    "react-native-pager-view": "7.0.1",
+    "react-native-pager-view": "8.0.2",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.0",
     "react-native-svg": "15.15.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,7 +97,7 @@ __metadata:
     react-native-collapsible-tab-view: "patch:react-native-collapsible-tab-view@npm%3A9.0.0-rc.0#~/.yarn/patches/react-native-collapsible-tab-view-npm-9.0.0-rc.0-5363b327de.patch"
     react-native-haptic-feedback: "npm:1.14.0"
     react-native-linear-gradient: "npm:2.8.3"
-    react-native-pager-view: "npm:7.0.1"
+    react-native-pager-view: "npm:8.0.2"
     react-native-popover-view: "npm:^6.1.0"
     react-native-reanimated: "npm:4.2.1"
     react-native-safe-area-context: "npm:5.6.0"
@@ -13603,6 +13603,16 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/94da200433156b33db6c3fe0b5f1e9c689155177298affd2aea4eef720343eb7d5a1897e211bdb438293e33917317e48a375e607ad9baa14a6d789bb03eccbc4
+  languageName: node
+  linkType: hard
+
+"react-native-pager-view@npm:8.0.2":
+  version: 8.0.2
+  resolution: "react-native-pager-view@npm:8.0.2"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/a2ba54ba413d07468d0f5d509071d9addb1281424c04293b9213a8f47fc097455b76109bef5e66272cdb04c1654d8eded6bc7ae3486341fa10dfc58c021defd6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Bumps `react-native-pager-view` to latest - used here as a dev dependency only for the collapsible-tab library

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
