### PR TITLE
fix: pill broken UI

### DIFF
--- a/src/elements/Pill/Pill.stories.tsx
+++ b/src/elements/Pill/Pill.stories.tsx
@@ -117,6 +117,9 @@ export const Onboarding = () => {
         Yes, I love collecting art
       </Pill>
       <Pill variant="onboarding">No, I'm just starting out</Pill>
+      <Pill variant="onboarding">
+        This is a long text that should break into lines, it should still look fine
+      </Pill>
     </List>
   )
 }

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -97,6 +97,7 @@ export const Pill: React.FC<PillProps> = ({
 const Container = styled(MotiPressable)<MotiPressableProps & PillProps>`
   align-items: center;
   border: 1px solid ${themeGet("colors.mono15")};
+  padding-vertical: 5px;
   flex-direction: row;
   justify-content: center;
   text-align: center;
@@ -119,7 +120,7 @@ const Thumbnail = styled(Image)`
 const PILL_STATES = {
   default: css`
     border-radius: 15px;
-    height: ${PixelRatio.getFontScale() * 30}px;
+    min-height: ${PixelRatio.getFontScale() * 30}px;
     padding-horizontal: 15px;
   `,
   selected: css`
@@ -139,7 +140,7 @@ const PILL_VARIANTS: Record<PillVariant, Record<PillState, RuleSet>> = {
     default: css`
       ${PILL_STATES.default}
       border-radius: 20px;
-      height: 40px;
+      min-height: 40px;
       border-color: ${themeGet("colors.mono60")};
     `,
   },
@@ -164,7 +165,7 @@ const PILL_VARIANTS: Record<PillVariant, Record<PillState, RuleSet>> = {
       background-color: ${themeGet("colors.mono5")};
       border-color: ${themeGet("colors.mono5")};
       border-radius: 25px;
-      height: 50px;
+      min-height: 50px;
       padding: 0 ${themeGet("space.1")};
     `,
     selected: css`
@@ -190,7 +191,7 @@ const PILL_VARIANTS: Record<PillVariant, Record<PillState, RuleSet>> = {
   filter: {
     ...PILL_STATES,
     default: css`
-      height: 30px;
+      min-height: 30px;
       padding: 0 ${themeGet("space.1")};
     `,
     disabled: css`


### PR DESCRIPTION
### Description
This PR fixes the pill size issues that I noticed on the new onboarding


| Platform | Before | After |
|--------|--------|--------|
| iOS | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-01 at 14 17 22" src="https://github.com/user-attachments/assets/372c385e-5a4c-42f8-b608-da39c01565d3" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-01 at 14 17 06" src="https://github.com/user-attachments/assets/1c610b67-f82e-4986-8dd6-9ab5832ce158" /> |
| Android | Cell | Cell | 

Working on screenshots on Adnroid / for some reason, the screen is not tappable

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
