### PR TITLE
fix(DI-498): onboarding pill scales with accessibility font size

### DIFF
--- a/src/elements/Pill/Pill.tests.tsx
+++ b/src/elements/Pill/Pill.tests.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react-native"
+import { StyleSheet } from "react-native"
 import { Pill } from "./Pill"
 import { Theme } from "../../Theme"
 
@@ -29,5 +30,35 @@ describe("Pill", () => {
 
     fireEvent.press(screen.getByText("Press me"))
     expect(onPress).not.toHaveBeenCalled()
+  })
+
+  it("switches the onboarding variant's text alignment from center to left once it wraps to multiple lines", () => {
+    render(
+      <Theme>
+        <Pill variant="onboarding">Some label</Pill>
+      </Theme>
+    )
+
+    expect(StyleSheet.flatten(screen.getByText("Some label").props.style).textAlign).toBe("center")
+
+    fireEvent(screen.getByText("Some label"), "textLayout", {
+      nativeEvent: { lines: [{}, {}] },
+    })
+
+    expect(StyleSheet.flatten(screen.getByText("Some label").props.style).textAlign).toBe("left")
+  })
+
+  it("leaves other variants' text alignment untouched regardless of line count", () => {
+    render(
+      <Theme>
+        <Pill variant="default">Some label</Pill>
+      </Theme>
+    )
+
+    fireEvent(screen.getByText("Some label"), "textLayout", {
+      nativeEvent: { lines: [{}, {}] },
+    })
+
+    expect(StyleSheet.flatten(screen.getByText("Some label").props.style).textAlign).toBeUndefined()
   })
 })

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -2,7 +2,7 @@ import { CloseIcon, IconProps } from "@artsy/icons/native"
 import { Color } from "@artsy/palette-tokens"
 import themeGet from "@styled-system/theme-get"
 import { MotiPressable, MotiPressableProps } from "moti/interactions"
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { PixelRatio, Platform } from "react-native"
 import styled, { RuleSet, css } from "styled-components"
 import { Flex, FlexProps } from "../Flex"
@@ -50,6 +50,7 @@ export const Pill: React.FC<PillProps> = ({
   const color = TEXT_COLOR[variant][stateString]
   const showCloseIcon =
     (variant === "filter" && !disabled) || (["profile"].includes(variant) && selected)
+  const [isMultiline, setIsMultiline] = useState(false)
 
   return (
     <Flex {...rest}>
@@ -80,6 +81,12 @@ export const Pill: React.FC<PillProps> = ({
         <Text
           variant="xs"
           color={color}
+          textAlign={variant === "onboarding" ? (isMultiline ? "left" : "center") : undefined}
+          onTextLayout={
+            variant === "onboarding"
+              ? (event) => setIsMultiline(event.nativeEvent.lines.length > 1)
+              : undefined
+          }
           style={Platform.select({
             android: { lineHeight: undefined },
             default: {},
@@ -137,9 +144,9 @@ const PILL_VARIANTS: Record<PillVariant, Record<PillState, RuleSet>> = {
   onboarding: {
     ...PILL_STATES,
     default: css`
-      ${PILL_STATES.default}
       border-radius: 20px;
-      height: 40px;
+      padding-horizontal: 15px;
+      padding-vertical: 10px;
       border-color: ${themeGet("colors.mono60")};
     `,
   },


### PR DESCRIPTION
This PR resolves [DI-498]

### Description

The `onboarding` Pill variant hardcoded a fixed `height: 40px`, so text grown via large accessibility font sizes (or wrapped onto a second line) got clipped instead of the pill growing to fit it.

- Swapped the fixed height for `padding-horizontal`/`padding-vertical` so the pill sizes itself from content instead of a fixed value, scoped to the `onboarding` variant only — no other variant's styles changed.
- Added multiline-aware text alignment: the label stays centered for a single line (unchanged look), but switches to left-aligned once `onTextLayout` reports more than one line, since centered text looks unbalanced once wrapped. Also scoped to `onboarding` only.
- Added tests covering the alignment switch and confirming other variants are unaffected.

Before/after screenshots and the original diagnosis live in the paired POC PR in eigen: https://github.com/artsy/eigen/pull/13862

### Test plan
- [x] `yarn test src/elements/Pill` — 4/4 passing
- [x] `yarn type-check`
- [x] `yarn lint`