### PR TITLE
fix(DI-498): split onboarding pill into new option variant, left-align text

### DIFF
--- a/src/elements/Pill/Pill.stories.tsx
+++ b/src/elements/Pill/Pill.stories.tsx
@@ -121,6 +121,21 @@ export const Onboarding = () => {
   )
 }
 
+export const Option = () => {
+  return (
+    <List contentContainerStyle={{ marginHorizontal: 20, gap: 1 }}>
+      <Flex backgroundColor="mono100" p={2} gap={1}>
+        <Pill variant="option" selected color="mono0">
+          Yes, I love collecting art
+        </Pill>
+        <Pill variant="option" color="mono0">
+          No, I'm just starting out
+        </Pill>
+      </Flex>
+    </List>
+  )
+}
+
 export const Link = () => {
   return (
     <List contentContainerStyle={{ marginHorizontal: 20 }}>

--- a/src/elements/Pill/Pill.tests.tsx
+++ b/src/elements/Pill/Pill.tests.tsx
@@ -32,33 +32,51 @@ describe("Pill", () => {
     expect(onPress).not.toHaveBeenCalled()
   })
 
-  it("switches the onboarding variant's text alignment from center to left once it wraps to multiple lines", () => {
+  it("left-aligns the option variant's text", () => {
     render(
       <Theme>
-        <Pill variant="onboarding">Some label</Pill>
+        <Pill variant="option">Some label</Pill>
       </Theme>
     )
-
-    expect(StyleSheet.flatten(screen.getByText("Some label").props.style).textAlign).toBe("center")
-
-    fireEvent(screen.getByText("Some label"), "textLayout", {
-      nativeEvent: { lines: [{}, {}] },
-    })
 
     expect(StyleSheet.flatten(screen.getByText("Some label").props.style).textAlign).toBe("left")
   })
 
-  it("leaves other variants' text alignment untouched regardless of line count", () => {
+  it("leaves other variants' text alignment untouched, including onboarding", () => {
     render(
       <Theme>
-        <Pill variant="default">Some label</Pill>
+        <>
+          <Pill variant="default">Some label</Pill>
+          <Pill variant="onboarding">Some other label</Pill>
+        </>
       </Theme>
     )
 
-    fireEvent(screen.getByText("Some label"), "textLayout", {
-      nativeEvent: { lines: [{}, {}] },
-    })
-
     expect(StyleSheet.flatten(screen.getByText("Some label").props.style).textAlign).toBeUndefined()
+    expect(
+      StyleSheet.flatten(screen.getByText("Some other label").props.style).textAlign
+    ).toBeUndefined()
+  })
+
+  it("uses the default per-state color when no color override is passed", () => {
+    render(
+      <Theme>
+        <Pill variant="option">Some label</Pill>
+      </Theme>
+    )
+
+    expect(StyleSheet.flatten(screen.getByText("Some label").props.style).color).toBe("#000000")
+  })
+
+  it("lets a color override win over the default per-state color", () => {
+    render(
+      <Theme>
+        <Pill variant="option" color="mono0">
+          Some label
+        </Pill>
+      </Theme>
+    )
+
+    expect(StyleSheet.flatten(screen.getByText("Some label").props.style).color).toBe("#FFFFFF")
   })
 })

--- a/src/elements/Pill/Pill.tsx
+++ b/src/elements/Pill/Pill.tsx
@@ -2,7 +2,7 @@ import { CloseIcon, IconProps } from "@artsy/icons/native"
 import { Color } from "@artsy/palette-tokens"
 import themeGet from "@styled-system/theme-get"
 import { MotiPressable, MotiPressableProps } from "moti/interactions"
-import { useMemo, useState } from "react"
+import { useMemo } from "react"
 import { PixelRatio, Platform } from "react-native"
 import styled, { RuleSet, css } from "styled-components"
 import { Flex, FlexProps } from "../Flex"
@@ -17,6 +17,7 @@ export const PILL_VARIANT_NAMES = [
   "profile",
   "search",
   "onboarding",
+  "option",
   "link",
 ] as const
 export type PillState = "default" | "selected" | "disabled"
@@ -27,6 +28,7 @@ export type PillProps = (FlexProps & {
   disabled?: boolean
   Icon?: React.FC<IconProps>
   onPress?: MotiPressableProps["onPress"]
+  color?: Color
 }) &
   (
     | {
@@ -44,13 +46,13 @@ export const Pill: React.FC<PillProps> = ({
   Icon,
   children,
   onPress,
+  color: colorOverride,
   ...rest
 }) => {
   const stateString = selected ? "selected" : disabled ? "disabled" : "default"
-  const color = TEXT_COLOR[variant][stateString]
+  const color = colorOverride ?? TEXT_COLOR[variant][stateString]
   const showCloseIcon =
     (variant === "filter" && !disabled) || (["profile"].includes(variant) && selected)
-  const [isMultiline, setIsMultiline] = useState(false)
 
   return (
     <Flex {...rest}>
@@ -81,12 +83,7 @@ export const Pill: React.FC<PillProps> = ({
         <Text
           variant="xs"
           color={color}
-          textAlign={variant === "onboarding" ? (isMultiline ? "left" : "center") : undefined}
-          onTextLayout={
-            variant === "onboarding"
-              ? (event) => setIsMultiline(event.nativeEvent.lines.length > 1)
-              : undefined
-          }
+          textAlign={variant === "option" ? "left" : undefined}
           style={Platform.select({
             android: { lineHeight: undefined },
             default: {},
@@ -142,6 +139,15 @@ const PILL_STATES = {
 const PILL_VARIANTS: Record<PillVariant, Record<PillState, RuleSet>> = {
   default: PILL_STATES,
   onboarding: {
+    ...PILL_STATES,
+    default: css`
+      ${PILL_STATES.default}
+      border-radius: 20px;
+      height: 40px;
+      border-color: ${themeGet("colors.mono60")};
+    `,
+  },
+  option: {
     ...PILL_STATES,
     default: css`
       border-radius: 20px;
@@ -223,6 +229,7 @@ const defaultColors: Record<PillState, Color> = {
 const TEXT_COLOR: Record<PillVariant, Record<PillState, Color>> = {
   default: defaultColors,
   onboarding: defaultColors,
+  option: defaultColors,
   dotted: {
     ...defaultColors,
     selected: "mono100",


### PR DESCRIPTION
This PR resolves [DI-498]
Assisted-by: Claude: Sonnet-5

### Description

Splits the onboarding-variant `Pill` (shared by the new and old onboarding flows) into `"onboarding"` (reverted to its original fixed-height layout, used by the old flow) and a new `"option"` variant (auto-grows to fit content, always left-aligns text). Also adds an optional `color` prop for callers to override text color when their background doesn't match the variant's themed default.

I introduced this split because the changes in #503 made the pills in the old onboarding flow look comically large, and I was spending a lot of time going back and forth between the two flows in order to reconcile them. This split allows me to (1) focus on the new onboarding flow and (2) create a more generic variant that is not tied to either onboarding flow.